### PR TITLE
feat: add git worktree support

### DIFF
--- a/src/rust/cli/src/commands/project/activate.rs
+++ b/src/rust/cli/src/commands/project/activate.rs
@@ -56,6 +56,7 @@ pub(super) async fn deactivate_project(project: Option<&str>) -> Result<()> {
         Ok(mut client) => {
             let request = DeprioritizeProjectRequest {
                 project_id: project_id.clone(),
+                watch_path: None,
             };
 
             match client.project().deprioritize_project(request).await {

--- a/src/rust/cli/src/commands/project/info.rs
+++ b/src/rust/cli/src/commands/project/info.rs
@@ -32,6 +32,10 @@ pub(super) async fn project_info(project: Option<&str>) -> Result<()> {
                         if let Some(remote) = status.git_remote {
                             output::kv("Git Remote", &remote);
                         }
+                        output::kv("Worktree", if status.is_worktree { "Yes" } else { "No" });
+                        if let Some(main_path) = status.main_worktree_path {
+                            output::kv("Main Working Tree", &main_path);
+                        }
                     } else {
                         output::warning("Project not found");
                         output::info("Use 'wqm project list' to see registered projects");

--- a/src/rust/cli/src/commands/project/list.rs
+++ b/src/rust/cli/src/commands/project/list.rs
@@ -76,7 +76,12 @@ fn print_project_list(
         } else {
             ServiceStatus::Inactive
         };
-        output::status_line(&proj.project_name, status);
+        let name_display = if proj.is_worktree {
+            format!("{} [worktree]", proj.project_name)
+        } else {
+            proj.project_name.clone()
+        };
+        output::status_line(&name_display, status);
         output::kv("  ID", &proj.project_id);
         output::kv("  Path", &proj.project_root);
         output::kv("  Priority", &proj.priority);

--- a/src/rust/cli/src/commands/project/register.rs
+++ b/src/rust/cli/src/commands/project/register.rs
@@ -70,6 +70,16 @@ pub(super) async fn register_project(
                     }
                     output::kv("Priority", &result.priority);
                     output::kv("Active", if result.is_active { "Yes" } else { "No" });
+                    if result.is_worktree {
+                        output::info(format!(
+                            "Note: This path is a git worktree. \
+                             It is indexed under project {}",
+                            result.project_id
+                        ));
+                        if let Some(watch_path) = &result.watch_path {
+                            output::kv("Watch Path", watch_path);
+                        }
+                    }
                 }
                 Err(e) => {
                     output::error(format!("Failed to register project: {}", e));

--- a/src/rust/daemon/core/src/daemon_state/archive.rs
+++ b/src/rust/daemon/core/src/daemon_state/archive.rs
@@ -16,6 +16,7 @@ impl DaemonStateManager {
                    wf.parent_watch_id, wf.submodule_path,
                    wf.git_remote_url, wf.remote_hash, wf.disambiguation_path, wf.is_active, wf.last_activity_at,
                    wf.is_paused, wf.pause_start_time, wf.is_archived, wf.last_commit_hash, wf.is_git_tracked,
+                   wf.is_worktree, wf.main_worktree_watch_id,
                    wf.library_mode,
                    wf.follow_symlinks, wf.enabled, wf.cleanup_on_disable,
                    wf.created_at, wf.updated_at, wf.last_scan

--- a/src/rust/daemon/core/src/daemon_state/disambiguation.rs
+++ b/src/rust/daemon/core/src/daemon_state/disambiguation.rs
@@ -19,6 +19,7 @@ impl DaemonStateManager {
                    parent_watch_id, submodule_path,
                    git_remote_url, remote_hash, disambiguation_path, is_active, last_activity_at,
                    is_paused, pause_start_time, is_archived, last_commit_hash, is_git_tracked,
+                   is_worktree, main_worktree_watch_id,
                    library_mode,
                    follow_symlinks, enabled, cleanup_on_disable,
                    created_at, updated_at, last_scan

--- a/src/rust/daemon/core/src/daemon_state/record.rs
+++ b/src/rust/daemon/core/src/daemon_state/record.rs
@@ -130,6 +130,8 @@ impl DaemonStateManager {
             is_archived: row.try_get::<i32, _>("is_archived").unwrap_or(0) != 0,
             last_commit_hash: row.try_get("last_commit_hash").unwrap_or(None),
             is_git_tracked: row.try_get::<i32, _>("is_git_tracked").unwrap_or(0) != 0,
+            // unwrap_or defaults handle pre-v31 databases lacking these columns.
+            // TODO: convert to ? after v0.2.0 when all databases are guaranteed migrated.
             is_worktree: row.try_get::<i32, _>("is_worktree").unwrap_or(0) != 0,
             main_worktree_watch_id: row.try_get("main_worktree_watch_id").unwrap_or(None),
             library_mode: row.try_get("library_mode")?,

--- a/src/rust/daemon/core/src/daemon_state/record.rs
+++ b/src/rust/daemon/core/src/daemon_state/record.rs
@@ -48,6 +48,10 @@ pub struct WatchFolderRecord {
     pub last_commit_hash: Option<String>,
     /// Whether this watch folder is git-tracked (has .git/ or .git file)
     pub is_git_tracked: bool,
+    /// Whether this watch folder is a git worktree (linked working tree)
+    pub is_worktree: bool,
+    /// Watch ID of the main worktree (None if not a linked worktree)
+    pub main_worktree_watch_id: Option<String>,
 
     // Library-specific fields (None for projects)
     /// Library mode: "sync" or "incremental"
@@ -126,6 +130,8 @@ impl DaemonStateManager {
             is_archived: row.try_get::<i32, _>("is_archived").unwrap_or(0) != 0,
             last_commit_hash: row.try_get("last_commit_hash").unwrap_or(None),
             is_git_tracked: row.try_get::<i32, _>("is_git_tracked").unwrap_or(0) != 0,
+            is_worktree: row.try_get::<i32, _>("is_worktree").unwrap_or(0) != 0,
+            main_worktree_watch_id: row.try_get("main_worktree_watch_id").unwrap_or(None),
             library_mode: row.try_get("library_mode")?,
             follow_symlinks: row.try_get::<i32, _>("follow_symlinks")? != 0,
             enabled: row.try_get::<i32, _>("enabled")? != 0,

--- a/src/rust/daemon/core/src/daemon_state/tests/mod.rs
+++ b/src/rust/daemon/core/src/daemon_state/tests/mod.rs
@@ -31,6 +31,8 @@ fn make_test_watch_folder(watch_id: &str, path: &str, tenant_id: &str) -> WatchF
         is_archived: false,
         last_commit_hash: None,
         is_git_tracked: false,
+        is_worktree: false,
+        main_worktree_watch_id: None,
         library_mode: None,
         follow_symlinks: false,
         enabled: true,

--- a/src/rust/daemon/core/src/daemon_state/tests/mod.rs
+++ b/src/rust/daemon/core/src/daemon_state/tests/mod.rs
@@ -10,6 +10,7 @@ mod operational_state_tests;
 mod registration_tests;
 mod submodule_tests;
 mod watch_folder_tests;
+mod worktree_tests;
 
 /// Build a `WatchFolderRecord` with sensible defaults.
 /// Override any field via the returned struct.

--- a/src/rust/daemon/core/src/daemon_state/tests/worktree_tests.rs
+++ b/src/rust/daemon/core/src/daemon_state/tests/worktree_tests.rs
@@ -1,0 +1,356 @@
+//! Tests for git worktree registration and data model correctness.
+
+use super::*;
+
+// ── worktree registration ───────────────────────────────────────────
+
+#[tokio::test]
+async fn test_worktree_registration_fields() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir.path().join("test_worktree_reg.db");
+    let manager = DaemonStateManager::new(&db_path).await.unwrap();
+    manager.initialize().await.unwrap();
+
+    // Register the main repo
+    let main_repo = WatchFolderRecord {
+        is_git_tracked: true,
+        ..make_test_watch_folder("main-001", "/repos/myproject", "shared-tenant")
+    };
+    manager.store_watch_folder(&main_repo).await.unwrap();
+
+    // Register a worktree pointing back to the main repo
+    let worktree = WatchFolderRecord {
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        ..make_test_watch_folder("wt-001", "/repos/myproject-feature", "shared-tenant")
+    };
+    manager.store_watch_folder(&worktree).await.unwrap();
+
+    // Verify main repo fields
+    let main_record = manager.get_watch_folder("main-001").await.unwrap().unwrap();
+    assert!(
+        !main_record.is_worktree,
+        "main repo should not be a worktree"
+    );
+    assert!(
+        main_record.main_worktree_watch_id.is_none(),
+        "main repo should have no main_worktree_watch_id"
+    );
+
+    // Verify worktree fields
+    let wt_record = manager.get_watch_folder("wt-001").await.unwrap().unwrap();
+    assert!(
+        wt_record.is_worktree,
+        "worktree entry must have is_worktree = true"
+    );
+    assert_eq!(
+        wt_record.main_worktree_watch_id.as_deref(),
+        Some("main-001"),
+        "worktree must reference the main repo's watch_id"
+    );
+    assert_eq!(
+        wt_record.tenant_id, main_record.tenant_id,
+        "worktree must share the same tenant_id as the main repo"
+    );
+}
+
+#[tokio::test]
+async fn test_multiple_worktrees_share_tenant_id() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir.path().join("test_multi_worktree.db");
+    let manager = DaemonStateManager::new(&db_path).await.unwrap();
+    manager.initialize().await.unwrap();
+
+    let tenant = "multi-wt-tenant";
+
+    // Main repo
+    let main_repo = WatchFolderRecord {
+        is_git_tracked: true,
+        ..make_test_watch_folder("main-001", "/repos/project", tenant)
+    };
+    manager.store_watch_folder(&main_repo).await.unwrap();
+
+    // Worktree A
+    let wt_a = WatchFolderRecord {
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        ..make_test_watch_folder("wt-a", "/repos/project-wt-a", tenant)
+    };
+    manager.store_watch_folder(&wt_a).await.unwrap();
+
+    // Worktree B
+    let wt_b = WatchFolderRecord {
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        ..make_test_watch_folder("wt-b", "/repos/project-wt-b", tenant)
+    };
+    manager.store_watch_folder(&wt_b).await.unwrap();
+
+    // Retrieve and verify
+    let records = manager
+        .list_watch_folders(Some("projects"), false)
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 3);
+
+    let worktrees: Vec<_> = records.iter().filter(|r| r.is_worktree).collect();
+    assert_eq!(
+        worktrees.len(),
+        2,
+        "exactly two entries should be worktrees"
+    );
+
+    for wt in &worktrees {
+        assert_eq!(
+            wt.tenant_id, tenant,
+            "worktree must share the main tenant_id"
+        );
+        assert_eq!(
+            wt.main_worktree_watch_id.as_deref(),
+            Some("main-001"),
+            "worktree must reference the main repo"
+        );
+    }
+
+    let main = records.iter().find(|r| !r.is_worktree).unwrap();
+    assert_eq!(main.watch_id, "main-001");
+    assert!(main.main_worktree_watch_id.is_none());
+}
+
+// ── concurrent activation ───────────────────────────────────────────
+
+#[tokio::test]
+async fn test_worktree_concurrent_activation_deactivate_one() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir.path().join("test_wt_activation.db");
+    let manager = DaemonStateManager::new(&db_path).await.unwrap();
+    manager.initialize().await.unwrap();
+
+    let tenant = "act-tenant";
+
+    // Main repo
+    let main_repo = WatchFolderRecord {
+        is_active: true,
+        is_git_tracked: true,
+        last_activity_at: Some(Utc::now()),
+        ..make_test_watch_folder("main-001", "/repos/proj", tenant)
+    };
+    manager.store_watch_folder(&main_repo).await.unwrap();
+
+    // Worktree A (active)
+    let wt_a = WatchFolderRecord {
+        is_active: true,
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        last_activity_at: Some(Utc::now()),
+        ..make_test_watch_folder("wt-a", "/repos/proj-wt-a", tenant)
+    };
+    manager.store_watch_folder(&wt_a).await.unwrap();
+
+    // Worktree B (active)
+    let wt_b = WatchFolderRecord {
+        is_active: true,
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        last_activity_at: Some(Utc::now()),
+        ..make_test_watch_folder("wt-b", "/repos/proj-wt-b", tenant)
+    };
+    manager.store_watch_folder(&wt_b).await.unwrap();
+
+    // Verify both worktrees are active
+    let wt_a_rec = manager.get_watch_folder("wt-a").await.unwrap().unwrap();
+    let wt_b_rec = manager.get_watch_folder("wt-b").await.unwrap().unwrap();
+    assert!(wt_a_rec.is_active);
+    assert!(wt_b_rec.is_active);
+
+    // Deactivate only worktree A by updating its record directly
+    let deactivated = WatchFolderRecord {
+        is_active: false,
+        ..wt_a_rec
+    };
+    manager.store_watch_folder(&deactivated).await.unwrap();
+
+    // Worktree A should be inactive
+    let wt_a_after = manager.get_watch_folder("wt-a").await.unwrap().unwrap();
+    assert!(!wt_a_after.is_active, "worktree A should be deactivated");
+
+    // Worktree B should remain active
+    let wt_b_after = manager.get_watch_folder("wt-b").await.unwrap().unwrap();
+    assert!(wt_b_after.is_active, "worktree B should remain active");
+
+    // Main repo should remain active
+    let main_after = manager.get_watch_folder("main-001").await.unwrap().unwrap();
+    assert!(main_after.is_active, "main repo should remain active");
+}
+
+// ── lifecycle path-scoped deactivation with worktree metadata ───────
+
+#[tokio::test]
+async fn test_worktree_path_scoped_deactivation_preserves_sibling() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir.path().join("test_wt_path_deact.db");
+    let manager = DaemonStateManager::new(&db_path).await.unwrap();
+    manager.initialize().await.unwrap();
+
+    let tenant = "path-deact-tenant";
+
+    // Main repo with is_worktree metadata
+    let main_repo = WatchFolderRecord {
+        is_git_tracked: true,
+        ..make_test_watch_folder("main-001", "/repos/proj", tenant)
+    };
+    manager.store_watch_folder(&main_repo).await.unwrap();
+
+    // Two worktrees with proper worktree metadata
+    let wt_a = WatchFolderRecord {
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        ..make_test_watch_folder("wt-a", "/repos/proj-wt-a", tenant)
+    };
+    manager.store_watch_folder(&wt_a).await.unwrap();
+
+    let wt_b = WatchFolderRecord {
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        ..make_test_watch_folder("wt-b", "/repos/proj-wt-b", tenant)
+    };
+    manager.store_watch_folder(&wt_b).await.unwrap();
+
+    // Use WatchFolderLifecycle for path-scoped activation/deactivation
+    use crate::lifecycle::WatchFolderLifecycle;
+    let lc = WatchFolderLifecycle::new(manager.pool().clone());
+
+    // Activate all via tenant
+    lc.activate_by_tenant(tenant, "projects").await.unwrap();
+
+    // All three should be active (is_active = 1)
+    for id in &["main-001", "wt-a", "wt-b"] {
+        let rec = manager.get_watch_folder(id).await.unwrap().unwrap();
+        assert!(
+            rec.is_active,
+            "{} should be active after tenant activation",
+            id
+        );
+    }
+
+    // Deactivate only worktree A by path
+    lc.deactivate_by_tenant_and_path(tenant, "/repos/proj-wt-a")
+        .await
+        .unwrap();
+
+    // Worktree A should now be inactive
+    let wt_a_after = manager.get_watch_folder("wt-a").await.unwrap().unwrap();
+    assert!(
+        !wt_a_after.is_active,
+        "worktree A should be deactivated by path"
+    );
+    // Worktree A should still have worktree metadata intact
+    assert!(wt_a_after.is_worktree);
+    assert_eq!(
+        wt_a_after.main_worktree_watch_id.as_deref(),
+        Some("main-001")
+    );
+
+    // Worktree B and main should remain active
+    let wt_b_after = manager.get_watch_folder("wt-b").await.unwrap().unwrap();
+    assert!(wt_b_after.is_active, "worktree B should remain active");
+
+    let main_after = manager.get_watch_folder("main-001").await.unwrap().unwrap();
+    assert!(main_after.is_active, "main repo should remain active");
+}
+
+// ── worktree appears in active project listing ──────────────────────
+
+#[tokio::test]
+async fn test_active_worktrees_listed_as_active_projects() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir.path().join("test_wt_active_list.db");
+    let manager = DaemonStateManager::new(&db_path).await.unwrap();
+    manager.initialize().await.unwrap();
+
+    let tenant = "list-tenant";
+
+    // Main repo (active)
+    let main_repo = WatchFolderRecord {
+        is_active: true,
+        is_git_tracked: true,
+        last_activity_at: Some(Utc::now()),
+        ..make_test_watch_folder("main-001", "/repos/proj", tenant)
+    };
+    manager.store_watch_folder(&main_repo).await.unwrap();
+
+    // Active worktree
+    let wt = WatchFolderRecord {
+        is_active: true,
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        last_activity_at: Some(Utc::now()),
+        ..make_test_watch_folder("wt-001", "/repos/proj-wt", tenant)
+    };
+    manager.store_watch_folder(&wt).await.unwrap();
+
+    let active = manager.list_active_projects().await.unwrap();
+    assert_eq!(
+        active.len(),
+        2,
+        "both main and worktree should be listed as active"
+    );
+
+    let worktree_entry = active.iter().find(|r| r.is_worktree);
+    assert!(
+        worktree_entry.is_some(),
+        "the worktree should appear in active list"
+    );
+    assert_eq!(worktree_entry.unwrap().watch_id, "wt-001");
+}
+
+// ── worktree update preserves metadata ──────────────────────────────
+
+#[tokio::test]
+async fn test_worktree_update_preserves_metadata() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir.path().join("test_wt_update.db");
+    let manager = DaemonStateManager::new(&db_path).await.unwrap();
+    manager.initialize().await.unwrap();
+
+    let tenant = "update-tenant";
+
+    // Register main + worktree
+    let main_repo = WatchFolderRecord {
+        is_git_tracked: true,
+        ..make_test_watch_folder("main-001", "/repos/proj", tenant)
+    };
+    manager.store_watch_folder(&main_repo).await.unwrap();
+
+    let wt = WatchFolderRecord {
+        is_git_tracked: true,
+        is_worktree: true,
+        main_worktree_watch_id: Some("main-001".to_string()),
+        ..make_test_watch_folder("wt-001", "/repos/proj-wt", tenant)
+    };
+    manager.store_watch_folder(&wt).await.unwrap();
+
+    // Update worktree (e.g., scan timestamp) via store_watch_folder (INSERT OR REPLACE)
+    let mut updated_wt = manager.get_watch_folder("wt-001").await.unwrap().unwrap();
+    updated_wt.last_scan = Some(Utc::now());
+    manager.store_watch_folder(&updated_wt).await.unwrap();
+
+    // Verify worktree metadata survived the update
+    let reloaded = manager.get_watch_folder("wt-001").await.unwrap().unwrap();
+    assert!(reloaded.is_worktree, "is_worktree must survive update");
+    assert_eq!(
+        reloaded.main_worktree_watch_id.as_deref(),
+        Some("main-001"),
+        "main_worktree_watch_id must survive update"
+    );
+    assert_eq!(reloaded.tenant_id, tenant);
+    assert!(reloaded.last_scan.is_some(), "last_scan should be set");
+}

--- a/src/rust/daemon/core/src/daemon_state/watch_crud.rs
+++ b/src/rust/daemon/core/src/daemon_state/watch_crud.rs
@@ -19,10 +19,11 @@ impl DaemonStateManager {
                 parent_watch_id, submodule_path,
                 git_remote_url, remote_hash, disambiguation_path, is_active, last_activity_at,
                 is_paused, pause_start_time, is_archived, last_commit_hash, is_git_tracked,
+                is_worktree, main_worktree_watch_id,
                 library_mode,
                 follow_symlinks, enabled, cleanup_on_disable,
                 created_at, updated_at, last_scan
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)
             "#,
         )
         .bind(&record.watch_id)
@@ -41,6 +42,8 @@ impl DaemonStateManager {
         .bind(record.is_archived as i32)
         .bind(&record.last_commit_hash)
         .bind(record.is_git_tracked as i32)
+        .bind(record.is_worktree as i32)
+        .bind(&record.main_worktree_watch_id)
         .bind(&record.library_mode)
         .bind(record.follow_symlinks as i32)
         .bind(record.enabled as i32)
@@ -81,6 +84,7 @@ impl DaemonStateManager {
                    parent_watch_id, submodule_path,
                    git_remote_url, remote_hash, disambiguation_path, is_active, last_activity_at,
                    is_paused, pause_start_time, is_archived, last_commit_hash, is_git_tracked,
+                   is_worktree, main_worktree_watch_id,
                    library_mode,
                    follow_symlinks, enabled, cleanup_on_disable,
                    created_at, updated_at, last_scan
@@ -109,6 +113,7 @@ impl DaemonStateManager {
                    parent_watch_id, submodule_path,
                    git_remote_url, remote_hash, disambiguation_path, is_active, last_activity_at,
                    is_paused, pause_start_time, is_archived, last_commit_hash, is_git_tracked,
+                   is_worktree, main_worktree_watch_id,
                    library_mode,
                    follow_symlinks, enabled, cleanup_on_disable,
                    created_at, updated_at, last_scan
@@ -150,6 +155,7 @@ impl DaemonStateManager {
                    parent_watch_id, submodule_path,
                    git_remote_url, remote_hash, disambiguation_path, is_active, last_activity_at,
                    is_paused, pause_start_time, is_archived, last_commit_hash, is_git_tracked,
+                   is_worktree, main_worktree_watch_id,
                    library_mode,
                    follow_symlinks, enabled, cleanup_on_disable,
                    created_at, updated_at, last_scan
@@ -183,6 +189,7 @@ impl DaemonStateManager {
                    parent_watch_id, submodule_path,
                    git_remote_url, remote_hash, disambiguation_path, is_active, last_activity_at,
                    is_paused, pause_start_time, is_archived, last_commit_hash, is_git_tracked,
+                   is_worktree, main_worktree_watch_id,
                    library_mode,
                    follow_symlinks, enabled, cleanup_on_disable,
                    created_at, updated_at, last_scan

--- a/src/rust/daemon/core/src/git/mod.rs
+++ b/src/rust/daemon/core/src/git/mod.rs
@@ -5,6 +5,7 @@ mod reflog;
 mod types;
 mod watcher;
 mod watcher_types;
+mod worktree;
 
 // Re-export from types
 pub use types::{detect_git_status, CacheStats, GitError, GitResult, GitStatus};
@@ -35,3 +36,6 @@ pub use diff_tree::{
     diff_tree, get_blob_hash, ls_tree_submodules, parse_diff_tree_output, FileChange,
     FileChangeStatus,
 };
+
+// Re-export from worktree
+pub use worktree::find_main_worktree_path;

--- a/src/rust/daemon/core/src/git/worktree.rs
+++ b/src/rust/daemon/core/src/git/worktree.rs
@@ -1,0 +1,160 @@
+use std::path::{Path, PathBuf};
+
+/// Find the main working tree path for a git worktree.
+///
+/// Given a worktree's git directory (e.g., `/main/.git/worktrees/feature`),
+/// reads the `commondir` file to find the main `.git` directory, then
+/// returns its parent as the main working tree root.
+///
+/// Returns `None` if:
+/// - The `commondir` file doesn't exist or is unreadable (not a worktree)
+/// - The resolved path doesn't exist on disk
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use workspace_qdrant_core::git::find_main_worktree_path;
+///
+/// // Given a worktree git dir like /repos/main/.git/worktrees/feature
+/// let main_root = find_main_worktree_path(Path::new("/repos/main/.git/worktrees/feature"));
+/// // Returns Some("/repos/main")
+/// ```
+pub fn find_main_worktree_path(worktree_git_dir: &Path) -> Option<PathBuf> {
+    let commondir_file = worktree_git_dir.join("commondir");
+    let content = std::fs::read_to_string(&commondir_file).ok()?;
+    let common_path = content.trim();
+
+    // Resolve absolute or relative path
+    let resolved = if Path::new(common_path).is_absolute() {
+        PathBuf::from(common_path)
+    } else {
+        worktree_git_dir.join(common_path)
+    };
+
+    // Canonicalize to resolve ".." components and verify existence
+    let canonical = resolved.canonicalize().ok()?;
+
+    // The common dir points to the main .git directory;
+    // its parent is the main working tree root
+    canonical.parent().map(Path::to_path_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// T-01: Verify correct path resolution from a simulated worktree structure
+    /// with a relative commondir path.
+    #[test]
+    fn test_find_main_worktree_path_relative_commondir() {
+        let temp = TempDir::new().unwrap();
+        let main_repo = temp.path().join("main-repo");
+
+        // Create main repo .git directory
+        let main_git = main_repo.join(".git");
+        fs::create_dir_all(&main_git).unwrap();
+
+        // Create worktree git dir: main-repo/.git/worktrees/feature
+        let worktree_git_dir = main_git.join("worktrees").join("feature");
+        fs::create_dir_all(&worktree_git_dir).unwrap();
+
+        // commondir typically contains a relative path like "../../"
+        // which resolves from worktrees/feature back to .git
+        fs::write(worktree_git_dir.join("commondir"), "../..\n").unwrap();
+
+        let result = find_main_worktree_path(&worktree_git_dir);
+        assert!(result.is_some(), "should resolve main worktree path");
+
+        let expected = main_repo.canonicalize().unwrap();
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    /// Test with an absolute commondir path.
+    #[test]
+    fn test_find_main_worktree_path_absolute_commondir() {
+        let temp = TempDir::new().unwrap();
+        let main_repo = temp.path().join("main-repo");
+
+        // Create main repo .git directory
+        let main_git = main_repo.join(".git");
+        fs::create_dir_all(&main_git).unwrap();
+
+        // Create worktree git dir somewhere else
+        let worktree_git_dir = temp.path().join("worktree-gitdir");
+        fs::create_dir_all(&worktree_git_dir).unwrap();
+
+        // Write absolute path to commondir
+        let abs_git_path = main_git.canonicalize().unwrap();
+        fs::write(
+            worktree_git_dir.join("commondir"),
+            abs_git_path.to_str().unwrap(),
+        )
+        .unwrap();
+
+        let result = find_main_worktree_path(&worktree_git_dir);
+        assert!(result.is_some(), "should resolve from absolute commondir");
+
+        let expected = main_repo.canonicalize().unwrap();
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    /// T-02: Non-worktree directory (no commondir file) returns None.
+    #[test]
+    fn test_find_main_worktree_path_no_commondir() {
+        let temp = TempDir::new().unwrap();
+        let result = find_main_worktree_path(temp.path());
+        assert!(
+            result.is_none(),
+            "should return None when commondir is missing"
+        );
+    }
+
+    /// Missing commondir file returns None.
+    #[test]
+    fn test_find_main_worktree_path_missing_commondir_file() {
+        let temp = TempDir::new().unwrap();
+        let fake_git_dir = temp.path().join("fake-git");
+        fs::create_dir_all(&fake_git_dir).unwrap();
+
+        let result = find_main_worktree_path(&fake_git_dir);
+        assert!(result.is_none());
+    }
+
+    /// commondir points to a non-existent path returns None.
+    #[test]
+    fn test_find_main_worktree_path_nonexistent_resolved_path() {
+        let temp = TempDir::new().unwrap();
+        let worktree_dir = temp.path().join("wt");
+        fs::create_dir_all(&worktree_dir).unwrap();
+
+        fs::write(worktree_dir.join("commondir"), "/nonexistent/path/.git\n").unwrap();
+
+        let result = find_main_worktree_path(&worktree_dir);
+        assert!(result.is_none(), "should return None for non-existent path");
+    }
+
+    /// commondir with extra whitespace is handled correctly.
+    #[test]
+    fn test_find_main_worktree_path_whitespace_in_commondir() {
+        let temp = TempDir::new().unwrap();
+        let main_repo = temp.path().join("main-repo");
+
+        let main_git = main_repo.join(".git");
+        fs::create_dir_all(&main_git).unwrap();
+
+        let worktree_git_dir = main_git.join("worktrees").join("feature");
+        fs::create_dir_all(&worktree_git_dir).unwrap();
+
+        // Extra whitespace and newlines
+        fs::write(worktree_git_dir.join("commondir"), "  ../..\n  ").unwrap();
+
+        let result = find_main_worktree_path(&worktree_git_dir);
+        assert!(result.is_some(), "should handle whitespace in commondir");
+
+        let expected = main_repo.canonicalize().unwrap();
+        assert_eq!(result.unwrap(), expected);
+    }
+}

--- a/src/rust/daemon/core/src/git/worktree.rs
+++ b/src/rust/daemon/core/src/git/worktree.rs
@@ -45,7 +45,18 @@ pub fn find_main_worktree_path(worktree_git_dir: &Path) -> Option<PathBuf> {
     };
 
     // Canonicalize to resolve ".." components and verify existence
-    let canonical = resolved.canonicalize().ok()?;
+    let canonical = match resolved.canonicalize() {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            warn!(
+                "Failed to canonicalize worktree common dir {}: {}",
+                resolved.display(),
+                e
+            );
+            return None;
+        }
+    };
 
     // The common dir points to the main .git directory;
     // its parent is the main working tree root

--- a/src/rust/daemon/core/src/git/worktree.rs
+++ b/src/rust/daemon/core/src/git/worktree.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use tracing::warn;
 
 /// Find the main working tree path for a git worktree.
 ///
@@ -7,7 +8,7 @@ use std::path::{Path, PathBuf};
 /// returns its parent as the main working tree root.
 ///
 /// Returns `None` if:
-/// - The `commondir` file doesn't exist or is unreadable (not a worktree)
+/// - The `commondir` file doesn't exist (not a worktree)
 /// - The resolved path doesn't exist on disk
 ///
 /// # Examples
@@ -22,7 +23,18 @@ use std::path::{Path, PathBuf};
 /// ```
 pub fn find_main_worktree_path(worktree_git_dir: &Path) -> Option<PathBuf> {
     let commondir_file = worktree_git_dir.join("commondir");
-    let content = std::fs::read_to_string(&commondir_file).ok()?;
+    let content = match std::fs::read_to_string(&commondir_file) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            warn!(
+                "Failed to read commondir at {}: {}",
+                commondir_file.display(),
+                e
+            );
+            return None;
+        }
+    };
     let common_path = content.trim();
 
     // Resolve absolute or relative path

--- a/src/rust/daemon/core/src/lifecycle/watch_folder.rs
+++ b/src/rust/daemon/core/src/lifecycle/watch_folder.rs
@@ -13,6 +13,7 @@
 //! | DaemonStateManager      | `deactivate_project_group`      |
 //! | PriorityManager         | `register_session`              |
 //! | PriorityManager         | `unregister_session`            |
+//! | PriorityManager         | `unregister_session_by_path`    |
 //! | PriorityManager         | `set_priority`                  |
 //! | PriorityManager         | `cleanup_orphaned_sessions`     |
 //! | SystemService (gRPC)    | `set_server_state`              |
@@ -258,6 +259,60 @@ impl WatchFolderLifecycle {
             rows
         );
         Ok(rows)
+    }
+
+    /// Decrement `is_active` by 1 (clamped to 0) for a specific `(tenant_id, path)`.
+    ///
+    /// Used by `PriorityManager::unregister_session_by_path` when a `watch_path`
+    /// is specified, so that only the targeted watch folder (e.g. a single
+    /// worktree) is deactivated rather than every entry sharing the same
+    /// `tenant_id`.
+    pub async fn deactivate_by_tenant_and_path(
+        &self,
+        tenant_id: &str,
+        path: &str,
+    ) -> Result<u64, WatchFolderLifecycleError> {
+        let result = sqlx::query(
+            r#"
+            UPDATE watch_folders
+            SET is_active = MAX(0, is_active - 1),
+                updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            WHERE tenant_id = ?1
+              AND path = ?2
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(path)
+        .execute(&self.pool)
+        .await?;
+
+        let rows = result.rows_affected();
+        info!(
+            "watch_folder lifecycle: tenant_id={} path={} \
+             -> is_active-1 ({} rows)",
+            tenant_id, path, rows
+        );
+        Ok(rows)
+    }
+
+    /// Query the current `is_active` value for a specific `(tenant_id, path)`.
+    ///
+    /// Returns `None` if no matching watch folder exists.
+    pub async fn get_is_active_by_tenant_and_path(
+        &self,
+        tenant_id: &str,
+        path: &str,
+    ) -> Result<Option<i32>, WatchFolderLifecycleError> {
+        let value = sqlx::query_scalar::<_, i32>(
+            "SELECT is_active FROM watch_folders \
+             WHERE tenant_id = ?1 AND path = ?2 LIMIT 1",
+        )
+        .bind(tenant_id)
+        .bind(path)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(value)
     }
 
     // ── watch-id-level operations ────────────────────────────────────

--- a/src/rust/daemon/core/src/lifecycle/watch_folder_tests.rs
+++ b/src/rust/daemon/core/src/lifecycle/watch_folder_tests.rs
@@ -355,3 +355,133 @@ async fn test_hard_reset_zeroes_all_sessions() {
     assert_eq!(rows, 1);
     assert_eq!(session_count(&pool, "w1").await, 0);
 }
+
+// ── path-scoped deactivation tests ──────────────────────────────────
+
+#[tokio::test]
+async fn test_deactivate_by_tenant_and_path_only_targets_one_entry() {
+    let pool = test_pool().await;
+    setup(&pool).await;
+
+    // Two watch folders sharing the same tenant (main + worktree)
+    insert_project(&pool, "main", "shared_t", "/main").await;
+    insert_project(&pool, "wt1", "shared_t", "/worktree1").await;
+
+    let lc = WatchFolderLifecycle::new(pool.clone());
+
+    // Activate both to is_active=2
+    lc.activate_by_tenant("shared_t", "projects").await.unwrap();
+    lc.activate_by_tenant("shared_t", "projects").await.unwrap();
+    assert_eq!(session_count(&pool, "main").await, 2);
+    assert_eq!(session_count(&pool, "wt1").await, 2);
+
+    // Deactivate only the worktree path
+    let rows = lc
+        .deactivate_by_tenant_and_path("shared_t", "/worktree1")
+        .await
+        .unwrap();
+    assert_eq!(rows, 1);
+
+    // Main is untouched, worktree decremented by 1
+    assert_eq!(session_count(&pool, "main").await, 2);
+    assert_eq!(session_count(&pool, "wt1").await, 1);
+}
+
+#[tokio::test]
+async fn test_deactivate_by_tenant_and_path_floors_at_zero() {
+    let pool = test_pool().await;
+    setup(&pool).await;
+    insert_project(&pool, "w1", "t_floor_p", "/floor_path").await;
+
+    let lc = WatchFolderLifecycle::new(pool.clone());
+
+    // Already at 0; must not go negative
+    lc.deactivate_by_tenant_and_path("t_floor_p", "/floor_path")
+        .await
+        .unwrap();
+    assert_eq!(session_count(&pool, "w1").await, 0);
+}
+
+#[tokio::test]
+async fn test_deactivate_by_tenant_and_path_nonexistent_returns_zero() {
+    let pool = test_pool().await;
+    setup(&pool).await;
+
+    let lc = WatchFolderLifecycle::new(pool.clone());
+
+    let rows = lc
+        .deactivate_by_tenant_and_path("no_tenant", "/no_path")
+        .await
+        .unwrap();
+    assert_eq!(rows, 0);
+}
+
+#[tokio::test]
+async fn test_get_is_active_by_tenant_and_path() {
+    let pool = test_pool().await;
+    setup(&pool).await;
+    insert_project(&pool, "w1", "t_query", "/query_path").await;
+
+    let lc = WatchFolderLifecycle::new(pool.clone());
+
+    // Initially 0
+    let val = lc
+        .get_is_active_by_tenant_and_path("t_query", "/query_path")
+        .await
+        .unwrap();
+    assert_eq!(val, Some(0));
+
+    // Activate twice
+    lc.activate_by_tenant("t_query", "projects").await.unwrap();
+    lc.activate_by_tenant("t_query", "projects").await.unwrap();
+
+    let val = lc
+        .get_is_active_by_tenant_and_path("t_query", "/query_path")
+        .await
+        .unwrap();
+    assert_eq!(val, Some(2));
+
+    // Nonexistent returns None
+    let val = lc
+        .get_is_active_by_tenant_and_path("t_query", "/wrong_path")
+        .await
+        .unwrap();
+    assert_eq!(val, None);
+}
+
+#[tokio::test]
+async fn test_path_scoped_refcount_full_lifecycle() {
+    let pool = test_pool().await;
+    setup(&pool).await;
+
+    // Simulate: main repo + two worktrees, same tenant
+    insert_project(&pool, "main", "wt_tenant", "/repo").await;
+    insert_project(&pool, "wt_a", "wt_tenant", "/repo-wt-a").await;
+    insert_project(&pool, "wt_b", "wt_tenant", "/repo-wt-b").await;
+
+    let lc = WatchFolderLifecycle::new(pool.clone());
+
+    // Session opens in worktree A (tenant-wide activate, as register_session does)
+    lc.activate_by_tenant("wt_tenant", "projects")
+        .await
+        .unwrap();
+    assert_eq!(session_count(&pool, "main").await, 1);
+    assert_eq!(session_count(&pool, "wt_a").await, 1);
+    assert_eq!(session_count(&pool, "wt_b").await, 1);
+
+    // Session opens in worktree B
+    lc.activate_by_tenant("wt_tenant", "projects")
+        .await
+        .unwrap();
+    assert_eq!(session_count(&pool, "main").await, 2);
+    assert_eq!(session_count(&pool, "wt_a").await, 2);
+    assert_eq!(session_count(&pool, "wt_b").await, 2);
+
+    // Worktree A session ends (path-scoped)
+    lc.deactivate_by_tenant_and_path("wt_tenant", "/repo-wt-a")
+        .await
+        .unwrap();
+    assert_eq!(session_count(&pool, "main").await, 2); // untouched
+    assert_eq!(session_count(&pool, "wt_a").await, 1); // decremented
+    assert_eq!(session_count(&pool, "wt_b").await, 2); // untouched
+}

--- a/src/rust/daemon/core/src/patterns/gitignore.rs
+++ b/src/rust/daemon/core/src/patterns/gitignore.rs
@@ -39,6 +39,7 @@
 use std::path::Path;
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use tracing::warn;
 
 /// Per-directory matcher for `.gitignore` and `.wqmignore` (Gate 0).
 ///
@@ -69,7 +70,9 @@ impl ProjectIgnoreMatcher {
         // the directory that contains the ignore file (same as git behaviour).
         let mut exclusion_builder = GitignoreBuilder::new(dir);
         if gitignore_path.exists() {
-            let _ = exclusion_builder.add(&gitignore_path);
+            if let Some(e) = exclusion_builder.add(&gitignore_path) {
+                warn!("Error reading {}: {}", gitignore_path.display(), e);
+            }
         }
 
         // Parse .wqmignore: split into exclusions and re-inclusions
@@ -136,11 +139,27 @@ fn parse_wqmignore(
 
         if let Some(pattern) = reinclusion_pattern {
             if !pattern.is_empty() {
-                let _ = reinc_builder.add_line(Some(wqmignore_path.to_path_buf()), pattern);
+                if let Err(e) = reinc_builder.add_line(Some(wqmignore_path.to_path_buf()), pattern)
+                {
+                    warn!(
+                        "Malformed re-inclusion pattern '{}' in {}: {}",
+                        pattern,
+                        wqmignore_path.display(),
+                        e
+                    );
+                }
                 has_reinclusions = true;
             }
         } else {
-            let _ = exclusion_builder.add_line(Some(wqmignore_path.to_path_buf()), trimmed);
+            if let Err(e) = exclusion_builder.add_line(Some(wqmignore_path.to_path_buf()), trimmed)
+            {
+                warn!(
+                    "Malformed exclusion pattern '{}' in {}: {}",
+                    trimmed,
+                    wqmignore_path.display(),
+                    e
+                );
+            }
         }
     }
 

--- a/src/rust/daemon/core/src/patterns/gitignore.rs
+++ b/src/rust/daemon/core/src/patterns/gitignore.rs
@@ -7,11 +7,29 @@
 //! `.wqmignore` lets users add wqm-specific exclusions without touching the
 //! project's `.gitignore`.
 //!
-//! ## .wqmignore negation syntax
+//! ## .wqmignore negation (re-inclusion) syntax
 //!
-//! Lines starting with `- ` (dash space) in `.wqmignore` **re-include** paths
-//! that `.gitignore` excludes. This allows indexing git-ignored files (e.g.,
-//! generated docs, build artifacts) without modifying `.gitignore`.
+//! `.wqmignore` supports two equivalent syntaxes for re-including paths that
+//! `.gitignore` excludes:
+//!
+//! - **Canonical**: `!pattern` — standard gitignore negation syntax
+//! - **Legacy alias**: `- pattern` (dash space) — accepted for backward compatibility
+//!
+//! Both syntaxes are functionally identical: they cause the daemon to index a
+//! path even when `.gitignore` excludes it. Use `!pattern` in new `.wqmignore`
+//! files; `- pattern` continues to work for existing files.
+//!
+//! Note: re-inclusions are applied with a separate high-priority matcher, which
+//! means they can override directory-level exclusions — something standard
+//! gitignore `!` cannot do on its own.
+//!
+//! ## Priority rules
+//!
+//! `.wqmignore` always takes precedence over `.gitignore`:
+//! - Both ignore → ignored
+//! - Both re-include → not ignored
+//! - `.gitignore` ignores, `.wqmignore` re-includes → **not ignored**
+//! - `.gitignore` re-includes, `.wqmignore` ignores → **ignored**
 //!
 //! Resolution order:
 //! 1. If `.wqmignore` re-includes the path → **not ignored** (overrides gitignore)
@@ -87,8 +105,10 @@ impl ProjectIgnoreMatcher {
 /// Parse `.wqmignore`, splitting lines into exclusions (added to `builder`)
 /// and re-inclusions (returned as a separate matcher).
 ///
-/// Re-inclusion lines start with `- ` (dash space). The pattern after the
-/// prefix is treated as a standard gitignore pattern.
+/// Re-inclusion lines use either the canonical `!pattern` syntax or the legacy
+/// `- pattern` (dash space) alias — both are functionally equivalent. The
+/// pattern is added to a dedicated re-inclusion matcher that takes priority
+/// over all exclusion rules.
 fn parse_wqmignore(
     dir: &Path,
     wqmignore_path: &Path,
@@ -104,8 +124,17 @@ fn parse_wqmignore(
             continue;
         }
 
-        if let Some(pattern) = trimmed.strip_prefix("- ") {
-            let pattern = pattern.trim();
+        // Canonical `!pattern` syntax or legacy `- pattern` alias — both
+        // indicate a re-inclusion that overrides .gitignore exclusions.
+        let reinclusion_pattern = if let Some(p) = trimmed.strip_prefix("- ") {
+            Some(p.trim())
+        } else if let Some(p) = trimmed.strip_prefix('!') {
+            Some(p.trim())
+        } else {
+            None
+        };
+
+        if let Some(pattern) = reinclusion_pattern {
             if !pattern.is_empty() {
                 let _ = reinc_builder.add_line(Some(wqmignore_path.to_path_buf()), pattern);
                 has_reinclusions = true;
@@ -277,6 +306,49 @@ mod tests {
         let m = ProjectIgnoreMatcher::for_dir(dir.path()).unwrap();
         assert!(!m.is_ignored(&dir.path().join("dist"), true));
         assert!(m.is_ignored(&dir.path().join("tmp"), true));
+    }
+
+    // ── canonical !pattern syntax ──────────────────────────────────────────
+
+    #[test]
+    fn wqmignore_exclamation_reinclusion_overrides_gitignore() {
+        let dir = tmp();
+        fs::write(dir.path().join(".gitignore"), "dist/\n").unwrap();
+        fs::write(dir.path().join(".wqmignore"), "!dist/\n").unwrap();
+        let m = ProjectIgnoreMatcher::for_dir(dir.path()).unwrap();
+        assert!(!m.is_ignored(&dir.path().join("dist"), true));
+    }
+
+    #[test]
+    fn wqmignore_exclamation_with_glob_pattern() {
+        let dir = tmp();
+        fs::write(dir.path().join(".gitignore"), "*.generated.js\n").unwrap();
+        fs::write(dir.path().join(".wqmignore"), "!*.generated.js\n").unwrap();
+        let m = ProjectIgnoreMatcher::for_dir(dir.path()).unwrap();
+        assert!(!m.is_ignored(&dir.path().join("api.generated.js"), false));
+    }
+
+    #[test]
+    fn wqmignore_mixed_legacy_and_canonical_syntax() {
+        let dir = tmp();
+        fs::write(dir.path().join(".gitignore"), "build/\nvendor/\n").unwrap();
+        fs::write(dir.path().join(".wqmignore"), "- build/\n!vendor/\n").unwrap();
+        let m = ProjectIgnoreMatcher::for_dir(dir.path()).unwrap();
+        // Both legacy `- build/` and canonical `!vendor/` re-include
+        assert!(!m.is_ignored(&dir.path().join("build"), true));
+        assert!(!m.is_ignored(&dir.path().join("vendor"), true));
+    }
+
+    #[test]
+    fn wqmignore_exclamation_does_not_affect_other_exclusions() {
+        let dir = tmp();
+        fs::write(dir.path().join(".gitignore"), "dist/\nnode_modules/\n").unwrap();
+        fs::write(dir.path().join(".wqmignore"), "!dist/\n").unwrap();
+        let m = ProjectIgnoreMatcher::for_dir(dir.path()).unwrap();
+        // dist/ re-included via canonical syntax
+        assert!(!m.is_ignored(&dir.path().join("dist"), true));
+        // node_modules/ still excluded by .gitignore
+        assert!(m.is_ignored(&dir.path().join("node_modules"), true));
     }
 
     #[test]

--- a/src/rust/daemon/core/src/priority_manager/manager.rs
+++ b/src/rust/daemon/core/src/priority_manager/manager.rs
@@ -103,6 +103,53 @@ impl PriorityManager {
         Ok(0)
     }
 
+    /// Deactivate a single watch folder by `(tenant_id, path)`.
+    ///
+    /// Decrements `is_active` by 1 (clamped to 0) for only the watch folder
+    /// at the specified path, leaving other entries for the same tenant
+    /// untouched. Returns the `is_active` value after the decrement.
+    pub async fn unregister_session_by_path(
+        &self,
+        tenant_id: &str,
+        path: &str,
+    ) -> PriorityResult<i32> {
+        if tenant_id.is_empty() {
+            return Err(PriorityError::EmptyParameter);
+        }
+
+        let lifecycle = WatchFolderLifecycle::new(self.db_pool.clone());
+
+        // Check existence before mutating
+        let current = lifecycle
+            .get_is_active_by_tenant_and_path(tenant_id, path)
+            .await?;
+
+        if current.is_none() {
+            return Err(PriorityError::ProjectNotFound(format!(
+                "{tenant_id} at path {path}"
+            )));
+        }
+
+        lifecycle
+            .deactivate_by_tenant_and_path(tenant_id, path)
+            .await?;
+
+        // Read back the updated value
+        let updated = lifecycle
+            .get_is_active_by_tenant_and_path(tenant_id, path)
+            .await?
+            .unwrap_or(0);
+
+        METRICS.session_ended(tenant_id, "normal", 0.0);
+
+        info!(
+            "Session unregistered for project {} at path {}: is_active={}",
+            tenant_id, path, updated
+        );
+
+        Ok(updated)
+    }
+
     /// Set project priority explicitly
     ///
     /// Maps a priority string ("high"/"normal") to a session count increment/decrement.

--- a/src/rust/daemon/core/src/priority_manager/manager.rs
+++ b/src/rust/daemon/core/src/priority_manager/manager.rs
@@ -113,7 +113,7 @@ impl PriorityManager {
         tenant_id: &str,
         path: &str,
     ) -> PriorityResult<i32> {
-        if tenant_id.is_empty() {
+        if tenant_id.is_empty() || path.is_empty() {
             return Err(PriorityError::EmptyParameter);
         }
 

--- a/src/rust/daemon/core/src/schema_version/mod.rs
+++ b/src/rust/daemon/core/src/schema_version/mod.rs
@@ -39,6 +39,7 @@ mod v27;
 mod v28;
 mod v29;
 mod v30;
+mod v31;
 
 use sqlx::{sqlite::SqliteRow, Row, SqlitePool};
 use thiserror::Error;
@@ -47,7 +48,7 @@ use tracing::{debug, info};
 pub use self::migration::{Migration, MigrationRegistry};
 
 /// Current schema version - increment when adding new migrations
-pub const CURRENT_SCHEMA_VERSION: i32 = 30;
+pub const CURRENT_SCHEMA_VERSION: i32 = 31;
 
 /// Errors that can occur during schema operations
 #[derive(Error, Debug)]
@@ -194,7 +195,7 @@ impl SchemaManager {
         self.run_migration_from_registry(&registry, version).await
     }
 
-    /// Build the migration registry with all 30 migrations.
+    /// Build the migration registry with all 31 migrations.
     fn build_registry() -> MigrationRegistry {
         let mut registry = MigrationRegistry::new();
         registry.register(Box::new(v01::V01Migration));
@@ -227,6 +228,7 @@ impl SchemaManager {
         registry.register(Box::new(v28::V28Migration));
         registry.register(Box::new(v29::V29Migration));
         registry.register(Box::new(v30::V30Migration));
+        registry.register(Box::new(v31::V31Migration));
         registry
     }
 

--- a/src/rust/daemon/core/src/schema_version/tests/versioned.rs
+++ b/src/rust/daemon/core/src/schema_version/tests/versioned.rs
@@ -589,3 +589,118 @@ async fn test_migration_v21_submodule_junction_table() {
         .unwrap();
     assert_eq!(count_after, 0, "CASCADE delete should remove junction rows");
 }
+
+#[sqlx::test]
+async fn test_migration_v31_worktree_columns() {
+    let pool = create_test_pool().await;
+    let manager = SchemaManager::new(pool.clone());
+    manager
+        .run_migrations()
+        .await
+        .expect("Failed to run migrations");
+
+    // Verify columns exist
+    let has_is_worktree: bool = sqlx::query_scalar(
+        "SELECT COUNT(*) > 0 FROM pragma_table_info('watch_folders') \
+         WHERE name = 'is_worktree'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(has_is_worktree, "is_worktree column should exist");
+
+    let has_main_worktree_watch_id: bool = sqlx::query_scalar(
+        "SELECT COUNT(*) > 0 FROM pragma_table_info('watch_folders') \
+         WHERE name = 'main_worktree_watch_id'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        has_main_worktree_watch_id,
+        "main_worktree_watch_id column should exist"
+    );
+
+    // Verify partial index exists
+    let has_index: bool = sqlx::query_scalar(
+        "SELECT COUNT(*) > 0 FROM sqlite_master \
+         WHERE type='index' AND name='idx_watch_main_worktree'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(has_index, "idx_watch_main_worktree index should exist");
+
+    // Insert a main working tree entry
+    sqlx::query(
+        "INSERT INTO watch_folders (watch_id, path, collection, tenant_id, is_worktree, created_at, updated_at)
+         VALUES ('w-main', '/tmp/repo', 'projects', 't1', 0, '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Insert a worktree entry pointing to the main tree
+    sqlx::query(
+        "INSERT INTO watch_folders (watch_id, path, collection, tenant_id, is_worktree, main_worktree_watch_id, created_at, updated_at)
+         VALUES ('w-wt', '/tmp/repo-wt', 'projects', 't1', 1, 'w-main', '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Verify default value for is_worktree
+    let is_worktree: i32 =
+        sqlx::query_scalar("SELECT is_worktree FROM watch_folders WHERE watch_id = 'w-main'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(is_worktree, 0, "is_worktree should be 0 for main tree");
+
+    let is_worktree_wt: i32 =
+        sqlx::query_scalar("SELECT is_worktree FROM watch_folders WHERE watch_id = 'w-wt'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(is_worktree_wt, 1, "is_worktree should be 1 for worktree");
+
+    // Verify main_worktree_watch_id FK value
+    let main_id: Option<String> = sqlx::query_scalar(
+        "SELECT main_worktree_watch_id FROM watch_folders WHERE watch_id = 'w-wt'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(main_id.as_deref(), Some("w-main"));
+
+    // Verify CHECK constraint rejects invalid is_worktree values
+    let invalid = sqlx::query(
+        "INSERT INTO watch_folders (watch_id, path, collection, tenant_id, is_worktree, created_at, updated_at)
+         VALUES ('w-bad', '/tmp/bad', 'projects', 't1', 2, '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+        invalid.is_err(),
+        "CHECK constraint should reject is_worktree = 2"
+    );
+}
+
+#[sqlx::test]
+async fn test_migration_v31_idempotent() {
+    let pool = create_test_pool().await;
+    let manager = SchemaManager::new(pool.clone());
+    manager.initialize().await.unwrap();
+
+    // Run all migrations up to v31
+    manager
+        .run_migrations()
+        .await
+        .expect("First migration run should succeed");
+
+    // Run v31 migration again directly (simulates idempotency)
+    manager
+        .run_migration(31)
+        .await
+        .expect("Running v31 again should not fail");
+}

--- a/src/rust/daemon/core/src/schema_version/v31.rs
+++ b/src/rust/daemon/core/src/schema_version/v31.rs
@@ -1,0 +1,82 @@
+//! Migration v31: Add git worktree columns to watch_folders table.
+//!
+//! Adds `is_worktree` flag and `main_worktree_watch_id` foreign key to
+//! distinguish worktree watch roots from main working tree watch roots.
+
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+use tracing::{debug, info};
+
+use super::migration::Migration;
+use super::SchemaError;
+
+pub struct V31Migration;
+
+#[async_trait]
+impl Migration for V31Migration {
+    async fn up(&self, pool: &SqlitePool) -> Result<(), SchemaError> {
+        info!("Migration v31: Adding git worktree columns to watch_folders");
+
+        // Add is_worktree column
+        let has_is_worktree: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('watch_folders') \
+             WHERE name = 'is_worktree'",
+        )
+        .fetch_one(pool)
+        .await?;
+
+        if !has_is_worktree {
+            debug!("Adding is_worktree column to watch_folders");
+            sqlx::query(
+                "ALTER TABLE watch_folders \
+                 ADD COLUMN is_worktree INTEGER DEFAULT 0 \
+                 CHECK (is_worktree IN (0, 1))",
+            )
+            .execute(pool)
+            .await?;
+        } else {
+            debug!("is_worktree column already exists, skipping");
+        }
+
+        // Add main_worktree_watch_id column
+        let has_main_worktree: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('watch_folders') \
+             WHERE name = 'main_worktree_watch_id'",
+        )
+        .fetch_one(pool)
+        .await?;
+
+        if !has_main_worktree {
+            debug!("Adding main_worktree_watch_id column to watch_folders");
+            sqlx::query(
+                "ALTER TABLE watch_folders \
+                 ADD COLUMN main_worktree_watch_id TEXT \
+                 REFERENCES watch_folders(watch_id) ON DELETE SET NULL",
+            )
+            .execute(pool)
+            .await?;
+        } else {
+            debug!("main_worktree_watch_id column already exists, skipping");
+        }
+
+        // Create partial index for efficient worktree lookups
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_watch_main_worktree \
+             ON watch_folders(main_worktree_watch_id) \
+             WHERE main_worktree_watch_id IS NOT NULL",
+        )
+        .execute(pool)
+        .await?;
+
+        info!("Migration v31 complete");
+        Ok(())
+    }
+
+    fn version(&self) -> i32 {
+        31
+    }
+
+    fn description(&self) -> &'static str {
+        "Add git worktree columns to watch_folders"
+    }
+}

--- a/src/rust/daemon/core/src/strategies/processing/tenant/mod.rs
+++ b/src/rust/daemon/core/src/strategies/processing/tenant/mod.rs
@@ -15,6 +15,7 @@ mod delete;
 mod grammar_warm;
 mod library;
 mod project;
+mod project_worktree;
 #[cfg(test)]
 mod tests;
 

--- a/src/rust/daemon/core/src/strategies/processing/tenant/project.rs
+++ b/src/rust/daemon/core/src/strategies/processing/tenant/project.rs
@@ -120,12 +120,18 @@ async fn insert_watch_folder(
         0
     };
 
+    // Detect worktree status and resolve main worktree watch_id if applicable
+    let (is_worktree, main_worktree_watch_id) =
+        resolve_worktree_info(ctx, item, payload, git_status).await;
+
     let result = sqlx::query(
         r#"INSERT OR IGNORE INTO watch_folders (
             watch_id, path, collection, tenant_id, is_active,
             git_remote_url, last_activity_at, follow_symlinks, enabled,
-            cleanup_on_disable, is_git_tracked, last_commit_hash, created_at, updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, 1, 0, ?8, ?9, ?7, ?7)"#,
+            cleanup_on_disable, is_git_tracked, last_commit_hash,
+            is_worktree, main_worktree_watch_id,
+            created_at, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, 1, 0, ?8, ?9, ?10, ?11, ?7, ?7)"#,
     )
     .bind(&watch_id)
     .bind(&payload.project_root)
@@ -136,6 +142,8 @@ async fn insert_watch_folder(
     .bind(&now)
     .bind(git_status.is_git as i32)
     .bind(&git_status.commit_hash)
+    .bind(is_worktree as i32)
+    .bind(&main_worktree_watch_id)
     .execute(ctx.queue_manager.pool())
     .await
     .map_err(|e| {
@@ -144,9 +152,15 @@ async fn insert_watch_folder(
 
     if result.rows_affected() > 0 {
         info!(
-            "Created watch_folder for tenant={} path={} (active={}, git={}, branch={}, worktree={})",
-            item.tenant_id, payload.project_root, is_active,
-            git_status.is_git, git_status.branch, git_status.is_worktree,
+            "Created watch_folder for tenant={} path={} \
+             (active={}, git={}, branch={}, worktree={}, main_wt_id={:?})",
+            item.tenant_id,
+            payload.project_root,
+            is_active,
+            git_status.is_git,
+            git_status.branch,
+            is_worktree,
+            main_worktree_watch_id,
         );
     } else {
         info!(
@@ -155,6 +169,73 @@ async fn insert_watch_folder(
         );
     }
     Ok(())
+}
+
+/// Resolve worktree information for a project being registered.
+///
+/// If `git_status.is_worktree` is true, resolves the git directory, finds the
+/// main worktree path, and looks up the corresponding watch_id from
+/// `watch_folders`. Returns `(is_worktree, main_worktree_watch_id)`.
+async fn resolve_worktree_info(
+    ctx: &ProcessingContext,
+    item: &UnifiedQueueItem,
+    payload: &ProjectPayload,
+    git_status: &crate::git::GitStatus,
+) -> (bool, Option<String>) {
+    if !git_status.is_worktree {
+        return (false, None);
+    }
+
+    let project_path = Path::new(&payload.project_root);
+    let git_dir = match crate::git::resolve_git_dir(project_path) {
+        Some(d) => d,
+        None => {
+            warn!(
+                "Worktree detected but could not resolve git dir for {}",
+                payload.project_root
+            );
+            return (true, None);
+        }
+    };
+
+    let main_path = match crate::git::find_main_worktree_path(&git_dir) {
+        Some(p) => p,
+        None => {
+            warn!(
+                "Worktree detected but could not find main worktree path for {}",
+                payload.project_root
+            );
+            return (true, None);
+        }
+    };
+
+    let main_path_str = main_path.to_string_lossy().to_string();
+    debug!(
+        "Worktree {} -> main worktree at {}",
+        payload.project_root, main_path_str
+    );
+
+    // Look up the watch_id of the main worktree in watch_folders
+    let main_watch_id: Option<String> = sqlx::query_scalar(
+        "SELECT watch_id FROM watch_folders \
+         WHERE path = ?1 AND tenant_id = ?2 AND collection = ?3",
+    )
+    .bind(&main_path_str)
+    .bind(&item.tenant_id)
+    .bind(COLLECTION_PROJECTS)
+    .fetch_optional(ctx.queue_manager.pool())
+    .await
+    .unwrap_or(None);
+
+    if main_watch_id.is_none() {
+        debug!(
+            "Main worktree {} not yet registered for tenant={}; \
+             main_worktree_watch_id will be NULL",
+            main_path_str, item.tenant_id
+        );
+    }
+
+    (true, main_watch_id)
 }
 
 async fn enqueue_project_scan(

--- a/src/rust/daemon/core/src/strategies/processing/tenant/project.rs
+++ b/src/rust/daemon/core/src/strategies/processing/tenant/project.rs
@@ -216,7 +216,7 @@ async fn resolve_worktree_info(
     );
 
     // Look up the watch_id of the main worktree in watch_folders
-    let main_watch_id: Option<String> = sqlx::query_scalar(
+    let main_watch_id = sqlx::query_scalar::<_, String>(
         "SELECT watch_id FROM watch_folders \
          WHERE path = ?1 AND tenant_id = ?2 AND collection = ?3",
     )
@@ -224,8 +224,18 @@ async fn resolve_worktree_info(
     .bind(&item.tenant_id)
     .bind(COLLECTION_PROJECTS)
     .fetch_optional(ctx.queue_manager.pool())
-    .await
-    .unwrap_or(None);
+    .await;
+
+    let main_watch_id = match main_watch_id {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(
+                "Failed to look up main worktree watch_id for path={} tenant={}: {}",
+                main_path_str, item.tenant_id, e
+            );
+            None
+        }
+    };
 
     if main_watch_id.is_none() {
         debug!(

--- a/src/rust/daemon/core/src/strategies/processing/tenant/project.rs
+++ b/src/rust/daemon/core/src/strategies/processing/tenant/project.rs
@@ -15,6 +15,7 @@ use crate::unified_queue_schema::{ItemType, ProjectPayload, QueueOperation, Unif
 use wqm_common::constants::COLLECTION_PROJECTS;
 
 use super::grammar_warm;
+use super::project_worktree::resolve_worktree_info;
 
 /// Process project item -- create/manage project collections.
 pub(crate) async fn process_project_item(
@@ -169,83 +170,6 @@ async fn insert_watch_folder(
         );
     }
     Ok(())
-}
-
-/// Resolve worktree information for a project being registered.
-///
-/// If `git_status.is_worktree` is true, resolves the git directory, finds the
-/// main worktree path, and looks up the corresponding watch_id from
-/// `watch_folders`. Returns `(is_worktree, main_worktree_watch_id)`.
-async fn resolve_worktree_info(
-    ctx: &ProcessingContext,
-    item: &UnifiedQueueItem,
-    payload: &ProjectPayload,
-    git_status: &crate::git::GitStatus,
-) -> (bool, Option<String>) {
-    if !git_status.is_worktree {
-        return (false, None);
-    }
-
-    let project_path = Path::new(&payload.project_root);
-    let git_dir = match crate::git::resolve_git_dir(project_path) {
-        Some(d) => d,
-        None => {
-            warn!(
-                "Worktree detected but could not resolve git dir for {}",
-                payload.project_root
-            );
-            return (true, None);
-        }
-    };
-
-    let main_path = match crate::git::find_main_worktree_path(&git_dir) {
-        Some(p) => p,
-        None => {
-            warn!(
-                "Worktree detected but could not find main worktree path for {}",
-                payload.project_root
-            );
-            return (true, None);
-        }
-    };
-
-    let main_path_str = main_path.to_string_lossy().to_string();
-    debug!(
-        "Worktree {} -> main worktree at {}",
-        payload.project_root, main_path_str
-    );
-
-    // Look up the watch_id of the main worktree in watch_folders
-    let main_watch_id = sqlx::query_scalar::<_, String>(
-        "SELECT watch_id FROM watch_folders \
-         WHERE path = ?1 AND tenant_id = ?2 AND collection = ?3",
-    )
-    .bind(&main_path_str)
-    .bind(&item.tenant_id)
-    .bind(COLLECTION_PROJECTS)
-    .fetch_optional(ctx.queue_manager.pool())
-    .await;
-
-    let main_watch_id = match main_watch_id {
-        Ok(v) => v,
-        Err(e) => {
-            warn!(
-                "Failed to look up main worktree watch_id for path={} tenant={}: {}",
-                main_path_str, item.tenant_id, e
-            );
-            None
-        }
-    };
-
-    if main_watch_id.is_none() {
-        debug!(
-            "Main worktree {} not yet registered for tenant={}; \
-             main_worktree_watch_id will be NULL",
-            main_path_str, item.tenant_id
-        );
-    }
-
-    (true, main_watch_id)
 }
 
 async fn enqueue_project_scan(

--- a/src/rust/daemon/core/src/strategies/processing/tenant/project_worktree.rs
+++ b/src/rust/daemon/core/src/strategies/processing/tenant/project_worktree.rs
@@ -1,0 +1,89 @@
+//! Worktree detection during project registration.
+//!
+//! Resolves whether a project path is a git worktree and looks up the
+//! main working tree's watch_id for the `main_worktree_watch_id` FK.
+
+use std::path::Path;
+
+use tracing::{debug, warn};
+
+use crate::context::ProcessingContext;
+use crate::unified_queue_schema::{ProjectPayload, UnifiedQueueItem};
+use wqm_common::constants::COLLECTION_PROJECTS;
+
+/// Resolve worktree information for a project being registered.
+///
+/// If `git_status.is_worktree` is true, resolves the git directory, finds the
+/// main worktree path, and looks up the corresponding watch_id from
+/// `watch_folders`. Returns `(is_worktree, main_worktree_watch_id)`.
+pub(super) async fn resolve_worktree_info(
+    ctx: &ProcessingContext,
+    item: &UnifiedQueueItem,
+    payload: &ProjectPayload,
+    git_status: &crate::git::GitStatus,
+) -> (bool, Option<String>) {
+    if !git_status.is_worktree {
+        return (false, None);
+    }
+
+    let project_path = Path::new(&payload.project_root);
+    let git_dir = match crate::git::resolve_git_dir(project_path) {
+        Some(d) => d,
+        None => {
+            warn!(
+                "Worktree detected but could not resolve git dir for {}",
+                payload.project_root
+            );
+            return (true, None);
+        }
+    };
+
+    let main_path = match crate::git::find_main_worktree_path(&git_dir) {
+        Some(p) => p,
+        None => {
+            warn!(
+                "Worktree detected but could not find main worktree path for {}",
+                payload.project_root
+            );
+            return (true, None);
+        }
+    };
+
+    let main_path_str = main_path.to_string_lossy().to_string();
+    debug!(
+        "Worktree {} -> main worktree at {}",
+        payload.project_root, main_path_str
+    );
+
+    // Look up the watch_id of the main worktree in watch_folders
+    let main_watch_id = sqlx::query_scalar::<_, String>(
+        "SELECT watch_id FROM watch_folders \
+         WHERE path = ?1 AND tenant_id = ?2 AND collection = ?3",
+    )
+    .bind(&main_path_str)
+    .bind(&item.tenant_id)
+    .bind(COLLECTION_PROJECTS)
+    .fetch_optional(ctx.queue_manager.pool())
+    .await;
+
+    let main_watch_id = match main_watch_id {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(
+                "Failed to look up main worktree watch_id for path={} tenant={}: {}",
+                main_path_str, item.tenant_id, e
+            );
+            None
+        }
+    };
+
+    if main_watch_id.is_none() {
+        debug!(
+            "Main worktree {} not yet registered for tenant={}; \
+             main_worktree_watch_id will be NULL",
+            main_path_str, item.tenant_id
+        );
+    }
+
+    (true, main_watch_id)
+}

--- a/src/rust/daemon/core/tests/watching_pause_tests.rs
+++ b/src/rust/daemon/core/tests/watching_pause_tests.rs
@@ -40,6 +40,8 @@ fn test_watch_record(id: &str, path: &str) -> WatchFolderRecord {
         is_archived: false,
         last_commit_hash: None,
         is_git_tracked: false,
+        is_worktree: false,
+        main_worktree_watch_id: None,
         library_mode: None,
         follow_symlinks: false,
         enabled: true,

--- a/src/rust/daemon/grpc/src/services/project_service/deactivation.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/deactivation.rs
@@ -2,6 +2,10 @@
 //!
 //! Handles deprioritization: unregistering sessions, updating watch_folders
 //! activity state, and triggering LSP shutdown (immediate or deferred).
+//!
+//! Supports path-scoped deactivation: when `watch_path` is set, only the
+//! specific watch folder at that path is decremented rather than all entries
+//! for the tenant.
 
 use tonic::Status;
 use tracing::{debug, error, info, warn};
@@ -20,11 +24,27 @@ impl ProjectServiceImpl {
             return Err(Status::invalid_argument("project_id cannot be empty"));
         }
 
-        info!("Deprioritizing project: {}", req.project_id);
+        let watch_path = req.watch_path.as_deref().filter(|p| !p.is_empty());
+
+        if let Some(path) = watch_path {
+            self.deprioritize_by_path(&req.project_id, path).await
+        } else {
+            self.deprioritize_tenant_wide(&req.project_id).await
+        }
+    }
+
+    /// Tenant-wide deprioritization (original behaviour).
+    ///
+    /// Decrements `is_active` for every watch folder sharing the `tenant_id`.
+    async fn deprioritize_tenant_wide(
+        &self,
+        project_id: &str,
+    ) -> Result<DeprioritizeProjectResponse, Status> {
+        info!("Deprioritizing project (tenant-wide): {}", project_id);
 
         match self
             .priority_manager
-            .unregister_session(&req.project_id, "main")
+            .unregister_session(project_id, "main")
             .await
         {
             Ok(active_flag) => {
@@ -32,13 +52,13 @@ impl ProjectServiceImpl {
                 let new_priority = if is_active { "high" } else { "normal" };
 
                 if !is_active {
-                    self.deactivate_project(&req.project_id).await;
-                    self.handle_lsp_shutdown(&req.project_id).await;
+                    self.deactivate_project(project_id).await;
+                    self.handle_lsp_shutdown(project_id).await;
 
                     if let Some(ref signal) = self.watch_refresh_signal {
                         signal.notify_one();
                         debug!(
-                            project_id = %req.project_id,
+                            project_id = %project_id,
                             "Signaled WatchManager refresh for project deactivation"
                         );
                     }
@@ -56,6 +76,62 @@ impl ProjectServiceImpl {
             }
             Err(e) => {
                 error!("Failed to deprioritize project: {e}");
+                Err(Status::internal(format!("Failed to deprioritize: {e}")))
+            }
+        }
+    }
+
+    /// Path-scoped deprioritization for worktree sessions.
+    ///
+    /// Decrements `is_active` only for the watch folder at `watch_path`,
+    /// leaving other entries for the same tenant untouched.
+    async fn deprioritize_by_path(
+        &self,
+        project_id: &str,
+        watch_path: &str,
+    ) -> Result<DeprioritizeProjectResponse, Status> {
+        info!(
+            "Deprioritizing project (path-scoped): {} at {}",
+            project_id, watch_path
+        );
+
+        match self
+            .priority_manager
+            .unregister_session_by_path(project_id, watch_path)
+            .await
+        {
+            Ok(active_flag) => {
+                let is_active = active_flag > 0;
+                let new_priority = if is_active { "high" } else { "normal" };
+
+                // When this specific path reaches zero, signal a watch refresh
+                // so the watcher can stop monitoring it if needed.
+                if !is_active {
+                    if let Some(ref signal) = self.watch_refresh_signal {
+                        signal.notify_one();
+                        debug!(
+                            project_id = %project_id,
+                            watch_path = %watch_path,
+                            "Signaled WatchManager refresh for path deactivation"
+                        );
+                    }
+                }
+
+                Ok(DeprioritizeProjectResponse {
+                    success: true,
+                    is_active,
+                    new_priority: new_priority.to_string(),
+                })
+            }
+            Err(workspace_qdrant_core::PriorityError::ProjectNotFound(id)) => {
+                warn!(
+                    "Watch folder not found for deprioritization: {} at {}",
+                    id, watch_path
+                );
+                Err(Status::not_found(format!("Watch folder not found: {id}")))
+            }
+            Err(e) => {
+                error!("Failed to deprioritize project by path: {e}");
                 Err(Status::internal(format!("Failed to deprioritize: {e}")))
             }
         }

--- a/src/rust/daemon/grpc/src/services/project_service/mod.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod lsp_lifecycle;
 mod mutations;
 mod queries;
 mod registration;
+mod worktree;
 
 #[cfg(test)]
 mod tests;

--- a/src/rust/daemon/grpc/src/services/project_service/queries.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/queries.rs
@@ -205,6 +205,7 @@ impl ProjectServiceImpl {
             priority: priority.to_string(),
             is_active: is_active_int == 1,
             last_active,
+            is_worktree: false,
         })
     }
 

--- a/src/rust/daemon/grpc/src/services/project_service/queries.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/queries.rs
@@ -31,9 +31,13 @@ impl ProjectServiceImpl {
         debug!("Getting project status: {}", req.project_id);
 
         let query = r#"
-            SELECT tenant_id, path, is_active, last_activity_at, created_at, git_remote_url
-            FROM watch_folders
-            WHERE tenant_id = ?1 AND collection = ?2
+            SELECT wf.tenant_id, wf.path, wf.is_active, wf.last_activity_at,
+                   wf.created_at, wf.git_remote_url, wf.is_worktree,
+                   wf.main_worktree_watch_id,
+                   mw.path AS main_worktree_path
+            FROM watch_folders wf
+            LEFT JOIN watch_folders mw ON wf.main_worktree_watch_id = mw.watch_id
+            WHERE wf.tenant_id = ?1 AND wf.collection = ?2
             LIMIT 1
         "#;
 
@@ -60,6 +64,8 @@ impl ProjectServiceImpl {
                 last_active: None,
                 registered_at: None,
                 git_remote: None,
+                is_worktree: false,
+                main_worktree_path: None,
             })
         }
     }
@@ -99,6 +105,9 @@ impl ProjectServiceImpl {
             .unwrap_or("")
             .to_string();
 
+        let is_worktree_int: i32 = row.try_get("is_worktree").unwrap_or(0);
+        let main_worktree_path: Option<String> = row.try_get("main_worktree_path").unwrap_or(None);
+
         Ok(GetProjectStatusResponse {
             found: true,
             project_id: row
@@ -113,6 +122,8 @@ impl ProjectServiceImpl {
             git_remote: row
                 .try_get("git_remote_url")
                 .map_err(|e| Status::internal(format!("Failed to get git_remote_url: {e}")))?,
+            is_worktree: is_worktree_int != 0,
+            main_worktree_path,
         })
     }
 
@@ -128,7 +139,7 @@ impl ProjectServiceImpl {
 
         let mut query = format!(
             r#"
-            SELECT tenant_id, path, is_active, last_activity_at
+            SELECT tenant_id, path, is_active, last_activity_at, is_worktree
             FROM watch_folders
             WHERE collection = '{COLLECTION_PROJECTS}'
             "#
@@ -196,6 +207,8 @@ impl ProjectServiceImpl {
             .unwrap_or("")
             .to_string();
 
+        let is_worktree_int: i32 = row.try_get("is_worktree").unwrap_or(0);
+
         Ok(ProjectInfo {
             project_id: row
                 .try_get("tenant_id")
@@ -205,7 +218,7 @@ impl ProjectServiceImpl {
             priority: priority.to_string(),
             is_active: is_active_int == 1,
             last_active,
-            is_worktree: false,
+            is_worktree: is_worktree_int != 0,
         })
     }
 

--- a/src/rust/daemon/grpc/src/services/project_service/registration.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/registration.rs
@@ -2,18 +2,22 @@
 //!
 //! Handles the RegisterProject gRPC flow: validation, project ID generation,
 //! queue enqueue for new projects, session registration for existing projects,
-//! LSP server startup, and activity inheritance.
+//! LSP server startup, activity inheritance, and worktree auto-registration.
 
 use std::path::{Path, PathBuf};
 
+use chrono::Utc;
 use tonic::Status;
 use tracing::{debug, error, info, warn};
+use uuid::Uuid;
 
 use crate::proto::{RegisterProjectRequest, RegisterProjectResponse};
 
 use workspace_qdrant_core::{
-    project_disambiguation::ProjectIdCalculator, ItemType, ProjectPayload, QueueManager,
-    UnifiedQueueOp,
+    daemon_state::WatchFolderRecord,
+    git::{detect_git_status, find_main_worktree_path, resolve_git_dir},
+    project_disambiguation::ProjectIdCalculator,
+    ItemType, ProjectPayload, QueueManager, UnifiedQueueOp,
 };
 use wqm_common::constants::COLLECTION_PROJECTS;
 use wqm_common::project_id::detect_git_remote;
@@ -30,6 +34,11 @@ enum RegistrationAction {
     NotFoundSkipped,
     /// New project enqueued for creation
     NewlyEnqueued { is_high_priority: bool },
+    /// Worktree auto-registered (main project exists, worktree path is new)
+    WorktreeAutoRegistered {
+        canonical_path: String,
+        is_high_priority: bool,
+    },
 }
 
 /// Resolve the git repository root from a given path by walking upward.
@@ -93,8 +102,13 @@ impl ProjectServiceImpl {
         );
 
         let action = self
-            .determine_registration_action(&project_id, &req, is_high_priority)
+            .determine_registration_action(&project_id, &req, is_high_priority, &effective_path)
             .await?;
+
+        // Look up worktree metadata for existing entries
+        let watch_meta = self
+            .lookup_watch_metadata(&project_id, &effective_path_str)
+            .await;
 
         match action {
             RegistrationAction::NotFoundSkipped => {
@@ -122,8 +136,8 @@ impl ProjectServiceImpl {
                     priority: effective_priority.to_string(),
                     is_active: true,
                     newly_registered: false,
-                    is_worktree: false,
-                    watch_path: None,
+                    is_worktree: watch_meta.is_worktree,
+                    watch_path: watch_meta.watch_path,
                 })
             }
             RegistrationAction::ExistingNoop => Ok(RegisterProjectResponse {
@@ -132,8 +146,8 @@ impl ProjectServiceImpl {
                 priority: effective_priority.to_string(),
                 is_active: false,
                 newly_registered: false,
-                is_worktree: false,
-                watch_path: None,
+                is_worktree: watch_meta.is_worktree,
+                watch_path: watch_meta.watch_path,
             }),
             RegistrationAction::NewlyEnqueued {
                 is_high_priority: hp,
@@ -151,6 +165,28 @@ impl ProjectServiceImpl {
                     newly_registered: true,
                     is_worktree: false,
                     watch_path: None,
+                })
+            }
+            RegistrationAction::WorktreeAutoRegistered {
+                canonical_path,
+                is_high_priority: hp,
+            } => {
+                if hp {
+                    self.activate_project(&project_id, &canonical_path).await;
+                }
+                self.signal_watch_refresh(&project_id);
+                Ok(RegisterProjectResponse {
+                    created: true,
+                    project_id,
+                    priority: if hp {
+                        "high".to_string()
+                    } else {
+                        effective_priority.to_string()
+                    },
+                    is_active: hp,
+                    newly_registered: true,
+                    is_worktree: true,
+                    watch_path: Some(canonical_path),
                 })
             }
         }
@@ -223,6 +259,7 @@ impl ProjectServiceImpl {
         project_id: &str,
         req: &RegisterProjectRequest,
         is_high_priority: bool,
+        effective_path: &Path,
     ) -> Result<RegistrationAction, Status> {
         if self.project_exists(project_id).await? {
             if is_high_priority {
@@ -241,11 +278,138 @@ impl ProjectServiceImpl {
                 Ok(RegistrationAction::ExistingNoop)
             }
         } else if !req.register_if_new {
-            Ok(RegistrationAction::NotFoundSkipped)
+            // Project not found and caller did not request auto-registration.
+            // Check if this path is a worktree whose main project is registered.
+            self.try_worktree_auto_register(effective_path, is_high_priority)
+                .await
         } else {
             self.enqueue_new_project(project_id, req, is_high_priority)
                 .await
         }
+    }
+
+    /// Attempt worktree auto-registration when the project is not found.
+    ///
+    /// Checks if the path is a git worktree and whether the main working tree
+    /// is already registered. If so, creates a new watch folder entry for the
+    /// worktree that shares the same tenant_id as the main project.
+    async fn try_worktree_auto_register(
+        &self,
+        effective_path: &Path,
+        is_high_priority: bool,
+    ) -> Result<RegistrationAction, Status> {
+        let git_status = detect_git_status(effective_path);
+        if !git_status.is_worktree {
+            return Ok(RegistrationAction::NotFoundSkipped);
+        }
+
+        // Resolve the worktree's git directory and find the main worktree root
+        let git_dir = resolve_git_dir(effective_path).ok_or_else(|| {
+            debug!(
+                path = %effective_path.display(),
+                "Worktree detected but could not resolve git dir"
+            );
+            Status::not_found("Worktree git directory not found")
+        })?;
+
+        let main_root = match find_main_worktree_path(&git_dir) {
+            Some(p) => p,
+            None => {
+                debug!(
+                    path = %effective_path.display(),
+                    "Could not resolve main worktree path"
+                );
+                return Ok(RegistrationAction::NotFoundSkipped);
+            }
+        };
+
+        // Compute the tenant_id for the main worktree
+        let main_remote = detect_git_remote(&main_root);
+        let calculator = ProjectIdCalculator::new();
+        let main_tenant_id = calculator.calculate(&main_root, main_remote.as_deref(), None);
+
+        // Look up the main project's watch folder by tenant_id
+        let main_watch = self.find_watch_folder_by_tenant(&main_tenant_id).await?;
+
+        let main_record = match main_watch {
+            Some(r) => r,
+            None => {
+                info!(
+                    path = %effective_path.display(),
+                    main_tenant_id = %main_tenant_id,
+                    "Worktree detected but main project not registered"
+                );
+                return Ok(RegistrationAction::NotFoundSkipped);
+            }
+        };
+
+        // Canonicalize the worktree path
+        let canonical_path =
+            std::fs::canonicalize(effective_path).unwrap_or_else(|_| effective_path.to_path_buf());
+        let canonical_str = canonical_path.to_string_lossy().to_string();
+
+        // Create the worktree watch folder record
+        let now = Utc::now();
+        let worktree_record = WatchFolderRecord {
+            watch_id: Uuid::new_v4().to_string(),
+            path: canonical_str.clone(),
+            collection: COLLECTION_PROJECTS.to_string(),
+            tenant_id: main_tenant_id.clone(),
+            parent_watch_id: None,
+            submodule_path: None,
+            git_remote_url: main_record.git_remote_url.clone(),
+            remote_hash: main_record.remote_hash.clone(),
+            disambiguation_path: main_record.disambiguation_path.clone(),
+            is_active: is_high_priority,
+            last_activity_at: if is_high_priority { Some(now) } else { None },
+            is_paused: false,
+            pause_start_time: None,
+            is_archived: false,
+            last_commit_hash: git_status.commit_hash,
+            is_git_tracked: true,
+            is_worktree: true,
+            main_worktree_watch_id: Some(main_record.watch_id.clone()),
+            library_mode: None,
+            follow_symlinks: main_record.follow_symlinks,
+            enabled: true,
+            cleanup_on_disable: main_record.cleanup_on_disable,
+            created_at: now,
+            updated_at: now,
+            last_scan: None,
+        };
+
+        // Insert the worktree record
+        self.state_manager
+            .store_watch_folder(&worktree_record)
+            .await
+            .map_err(|e| {
+                error!("Failed to store worktree watch folder: {e}");
+                Status::internal(format!("Failed to store worktree watch folder: {e}"))
+            })?;
+
+        info!(
+            "Auto-registering worktree: {} for project {}",
+            canonical_str, main_tenant_id
+        );
+
+        Ok(RegistrationAction::WorktreeAutoRegistered {
+            canonical_path: canonical_str,
+            is_high_priority,
+        })
+    }
+
+    /// Find a watch folder entry by tenant_id in the projects collection.
+    async fn find_watch_folder_by_tenant(
+        &self,
+        tenant_id: &str,
+    ) -> Result<Option<WatchFolderRecord>, Status> {
+        self.state_manager
+            .get_watch_folder_by_tenant_id(tenant_id, COLLECTION_PROJECTS)
+            .await
+            .map_err(|e| {
+                error!("Database error looking up watch folder by tenant: {e}");
+                Status::internal(format!("Database error: {e}"))
+            })
     }
 
     /// Enqueue a new project registration via (Tenant, Add)
@@ -420,4 +584,42 @@ impl ProjectServiceImpl {
             Ok(false)
         }
     }
+
+    /// Look up worktree metadata (is_worktree, watch_path) for an existing project.
+    ///
+    /// Queries the watch_folders table for the given path or tenant_id to populate
+    /// the `is_worktree` and `watch_path` response fields.
+    async fn lookup_watch_metadata(&self, project_id: &str, path: &str) -> WatchMetadata {
+        // Try path-exact match first, then fallback to tenant_id
+        let row: Option<(i32, String)> = sqlx::query_as(
+            r#"SELECT is_worktree, path FROM watch_folders
+               WHERE collection = ?1
+                 AND (path = ?2 OR tenant_id = ?3)
+               ORDER BY CASE WHEN path = ?2 THEN 0 ELSE 1 END
+               LIMIT 1"#,
+        )
+        .bind(COLLECTION_PROJECTS)
+        .bind(path)
+        .bind(project_id)
+        .fetch_optional(&self.db_pool)
+        .await
+        .unwrap_or(None);
+
+        match row {
+            Some((is_wt, watch_path)) => WatchMetadata {
+                is_worktree: is_wt != 0,
+                watch_path: Some(watch_path),
+            },
+            None => WatchMetadata {
+                is_worktree: false,
+                watch_path: None,
+            },
+        }
+    }
+}
+
+/// Worktree metadata for populating response fields on existing entries.
+struct WatchMetadata {
+    is_worktree: bool,
+    watch_path: Option<String>,
 }

--- a/src/rust/daemon/grpc/src/services/project_service/registration.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/registration.rs
@@ -2,26 +2,25 @@
 //!
 //! Handles the RegisterProject gRPC flow: validation, project ID generation,
 //! queue enqueue for new projects, session registration for existing projects,
-//! LSP server startup, activity inheritance, and worktree auto-registration.
+//! LSP server startup, and activity inheritance.
+//!
+//! Worktree auto-registration logic is in the sibling `worktree` module.
 
 use std::path::{Path, PathBuf};
 
-use chrono::Utc;
 use tonic::Status;
 use tracing::{debug, error, info, warn};
-use uuid::Uuid;
 
 use crate::proto::{RegisterProjectRequest, RegisterProjectResponse};
 
 use workspace_qdrant_core::{
-    daemon_state::WatchFolderRecord,
-    git::{detect_git_status, find_main_worktree_path, resolve_git_dir},
-    project_disambiguation::ProjectIdCalculator,
-    ItemType, ProjectPayload, QueueManager, UnifiedQueueOp,
+    project_disambiguation::ProjectIdCalculator, ItemType, ProjectPayload, QueueManager,
+    UnifiedQueueOp,
 };
 use wqm_common::constants::COLLECTION_PROJECTS;
 use wqm_common::project_id::detect_git_remote;
 
+use super::worktree::WorktreeResult;
 use super::ProjectServiceImpl;
 
 /// Result of determining what action to take for a registration request
@@ -35,10 +34,7 @@ enum RegistrationAction {
     /// New project enqueued for creation
     NewlyEnqueued { is_high_priority: bool },
     /// Worktree auto-registered (main project exists, worktree path is new)
-    WorktreeAutoRegistered {
-        canonical_path: String,
-        is_high_priority: bool,
-    },
+    WorktreeAutoRegistered { result: WorktreeResult },
 }
 
 /// Resolve the git repository root from a given path by walking upward.
@@ -167,27 +163,32 @@ impl ProjectServiceImpl {
                     watch_path: None,
                 })
             }
-            RegistrationAction::WorktreeAutoRegistered {
-                canonical_path,
-                is_high_priority: hp,
-            } => {
-                if hp {
-                    self.activate_project(&project_id, &canonical_path).await;
+            RegistrationAction::WorktreeAutoRegistered { result } => {
+                if let WorktreeResult::Registered {
+                    canonical_path,
+                    is_high_priority: hp,
+                } = result
+                {
+                    if hp {
+                        self.activate_project(&project_id, &canonical_path).await;
+                    }
+                    self.signal_watch_refresh(&project_id);
+                    Ok(RegisterProjectResponse {
+                        created: true,
+                        project_id,
+                        priority: if hp {
+                            "high".to_string()
+                        } else {
+                            effective_priority.to_string()
+                        },
+                        is_active: hp,
+                        newly_registered: true,
+                        is_worktree: true,
+                        watch_path: Some(canonical_path),
+                    })
+                } else {
+                    unreachable!("WorktreeAutoRegistered always contains Registered variant")
                 }
-                self.signal_watch_refresh(&project_id);
-                Ok(RegisterProjectResponse {
-                    created: true,
-                    project_id,
-                    priority: if hp {
-                        "high".to_string()
-                    } else {
-                        effective_priority.to_string()
-                    },
-                    is_active: hp,
-                    newly_registered: true,
-                    is_worktree: true,
-                    watch_path: Some(canonical_path),
-                })
             }
         }
     }
@@ -280,136 +281,19 @@ impl ProjectServiceImpl {
         } else if !req.register_if_new {
             // Project not found and caller did not request auto-registration.
             // Check if this path is a worktree whose main project is registered.
-            self.try_worktree_auto_register(effective_path, is_high_priority)
-                .await
+            let wt_result = self
+                .try_worktree_auto_register(effective_path, is_high_priority)
+                .await?;
+            match wt_result {
+                WorktreeResult::Registered { .. } => {
+                    Ok(RegistrationAction::WorktreeAutoRegistered { result: wt_result })
+                }
+                WorktreeResult::NotApplicable => Ok(RegistrationAction::NotFoundSkipped),
+            }
         } else {
             self.enqueue_new_project(project_id, req, is_high_priority)
                 .await
         }
-    }
-
-    /// Attempt worktree auto-registration when the project is not found.
-    ///
-    /// Checks if the path is a git worktree and whether the main working tree
-    /// is already registered. If so, creates a new watch folder entry for the
-    /// worktree that shares the same tenant_id as the main project.
-    async fn try_worktree_auto_register(
-        &self,
-        effective_path: &Path,
-        is_high_priority: bool,
-    ) -> Result<RegistrationAction, Status> {
-        let git_status = detect_git_status(effective_path);
-        if !git_status.is_worktree {
-            return Ok(RegistrationAction::NotFoundSkipped);
-        }
-
-        // Resolve the worktree's git directory and find the main worktree root
-        let git_dir = resolve_git_dir(effective_path).ok_or_else(|| {
-            debug!(
-                path = %effective_path.display(),
-                "Worktree detected but could not resolve git dir"
-            );
-            Status::not_found("Worktree git directory not found")
-        })?;
-
-        let main_root = match find_main_worktree_path(&git_dir) {
-            Some(p) => p,
-            None => {
-                debug!(
-                    path = %effective_path.display(),
-                    "Could not resolve main worktree path"
-                );
-                return Ok(RegistrationAction::NotFoundSkipped);
-            }
-        };
-
-        // Compute the tenant_id for the main worktree
-        let main_remote = detect_git_remote(&main_root);
-        let calculator = ProjectIdCalculator::new();
-        let main_tenant_id = calculator.calculate(&main_root, main_remote.as_deref(), None);
-
-        // Look up the main project's watch folder by tenant_id
-        let main_watch = self.find_watch_folder_by_tenant(&main_tenant_id).await?;
-
-        let main_record = match main_watch {
-            Some(r) => r,
-            None => {
-                info!(
-                    path = %effective_path.display(),
-                    main_tenant_id = %main_tenant_id,
-                    "Worktree detected but main project not registered"
-                );
-                return Ok(RegistrationAction::NotFoundSkipped);
-            }
-        };
-
-        // Canonicalize the worktree path
-        let canonical_path =
-            std::fs::canonicalize(effective_path).unwrap_or_else(|_| effective_path.to_path_buf());
-        let canonical_str = canonical_path.to_string_lossy().to_string();
-
-        // Create the worktree watch folder record
-        let now = Utc::now();
-        let worktree_record = WatchFolderRecord {
-            watch_id: Uuid::new_v4().to_string(),
-            path: canonical_str.clone(),
-            collection: COLLECTION_PROJECTS.to_string(),
-            tenant_id: main_tenant_id.clone(),
-            parent_watch_id: None,
-            submodule_path: None,
-            git_remote_url: main_record.git_remote_url.clone(),
-            remote_hash: main_record.remote_hash.clone(),
-            disambiguation_path: main_record.disambiguation_path.clone(),
-            is_active: is_high_priority,
-            last_activity_at: if is_high_priority { Some(now) } else { None },
-            is_paused: false,
-            pause_start_time: None,
-            is_archived: false,
-            last_commit_hash: git_status.commit_hash,
-            is_git_tracked: true,
-            is_worktree: true,
-            main_worktree_watch_id: Some(main_record.watch_id.clone()),
-            library_mode: None,
-            follow_symlinks: main_record.follow_symlinks,
-            enabled: true,
-            cleanup_on_disable: main_record.cleanup_on_disable,
-            created_at: now,
-            updated_at: now,
-            last_scan: None,
-        };
-
-        // Insert the worktree record
-        self.state_manager
-            .store_watch_folder(&worktree_record)
-            .await
-            .map_err(|e| {
-                error!("Failed to store worktree watch folder: {e}");
-                Status::internal(format!("Failed to store worktree watch folder: {e}"))
-            })?;
-
-        info!(
-            "Auto-registering worktree: {} for project {}",
-            canonical_str, main_tenant_id
-        );
-
-        Ok(RegistrationAction::WorktreeAutoRegistered {
-            canonical_path: canonical_str,
-            is_high_priority,
-        })
-    }
-
-    /// Find a watch folder entry by tenant_id in the projects collection.
-    async fn find_watch_folder_by_tenant(
-        &self,
-        tenant_id: &str,
-    ) -> Result<Option<WatchFolderRecord>, Status> {
-        self.state_manager
-            .get_watch_folder_by_tenant_id(tenant_id, COLLECTION_PROJECTS)
-            .await
-            .map_err(|e| {
-                error!("Database error looking up watch folder by tenant: {e}");
-                Status::internal(format!("Database error: {e}"))
-            })
     }
 
     /// Enqueue a new project registration via (Tenant, Add)
@@ -584,42 +468,4 @@ impl ProjectServiceImpl {
             Ok(false)
         }
     }
-
-    /// Look up worktree metadata (is_worktree, watch_path) for an existing project.
-    ///
-    /// Queries the watch_folders table for the given path or tenant_id to populate
-    /// the `is_worktree` and `watch_path` response fields.
-    async fn lookup_watch_metadata(&self, project_id: &str, path: &str) -> WatchMetadata {
-        // Try path-exact match first, then fallback to tenant_id
-        let row: Option<(i32, String)> = sqlx::query_as(
-            r#"SELECT is_worktree, path FROM watch_folders
-               WHERE collection = ?1
-                 AND (path = ?2 OR tenant_id = ?3)
-               ORDER BY CASE WHEN path = ?2 THEN 0 ELSE 1 END
-               LIMIT 1"#,
-        )
-        .bind(COLLECTION_PROJECTS)
-        .bind(path)
-        .bind(project_id)
-        .fetch_optional(&self.db_pool)
-        .await
-        .unwrap_or(None);
-
-        match row {
-            Some((is_wt, watch_path)) => WatchMetadata {
-                is_worktree: is_wt != 0,
-                watch_path: Some(watch_path),
-            },
-            None => WatchMetadata {
-                is_worktree: false,
-                watch_path: None,
-            },
-        }
-    }
-}
-
-/// Worktree metadata for populating response fields on existing entries.
-struct WatchMetadata {
-    is_worktree: bool,
-    watch_path: Option<String>,
 }

--- a/src/rust/daemon/grpc/src/services/project_service/registration.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/registration.rs
@@ -108,6 +108,8 @@ impl ProjectServiceImpl {
                     priority: "none".to_string(),
                     is_active: false,
                     newly_registered: false,
+                    is_worktree: false,
+                    watch_path: None,
                 })
             }
             RegistrationAction::ExistingActivated => {
@@ -120,6 +122,8 @@ impl ProjectServiceImpl {
                     priority: effective_priority.to_string(),
                     is_active: true,
                     newly_registered: false,
+                    is_worktree: false,
+                    watch_path: None,
                 })
             }
             RegistrationAction::ExistingNoop => Ok(RegisterProjectResponse {
@@ -128,6 +132,8 @@ impl ProjectServiceImpl {
                 priority: effective_priority.to_string(),
                 is_active: false,
                 newly_registered: false,
+                is_worktree: false,
+                watch_path: None,
             }),
             RegistrationAction::NewlyEnqueued {
                 is_high_priority: hp,
@@ -143,6 +149,8 @@ impl ProjectServiceImpl {
                     priority: effective_priority.to_string(),
                     is_active: hp,
                     newly_registered: true,
+                    is_worktree: false,
+                    watch_path: None,
                 })
             }
         }

--- a/src/rust/daemon/grpc/src/services/project_service/tests/lifecycle_tests.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/tests/lifecycle_tests.rs
@@ -66,6 +66,7 @@ async fn test_deferred_shutdown_scheduled_when_delay_set() {
 
     let request = Request::new(DeprioritizeProjectRequest {
         project_id: "abcd12345678".to_string(),
+        watch_path: None,
     });
     service.deprioritize_project(request).await.unwrap();
 
@@ -93,6 +94,7 @@ async fn test_reactivation_cancels_deferred_shutdown() {
 
     let request = Request::new(DeprioritizeProjectRequest {
         project_id: "abcd12345678".to_string(),
+        watch_path: None,
     });
     service.deprioritize_project(request).await.unwrap();
 

--- a/src/rust/daemon/grpc/src/services/project_service/tests/query_tests.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/tests/query_tests.rs
@@ -30,7 +30,7 @@ async fn test_deprioritize_project() {
 
     let request = Request::new(DeprioritizeProjectRequest {
         project_id: "abcd12345678".to_string(),
-    });
+        watch_path: None,    });
 
     let response = service.deprioritize_project(request).await.unwrap();
     let response = response.into_inner();
@@ -141,7 +141,7 @@ async fn test_list_projects_active_only() {
 
     let request = Request::new(DeprioritizeProjectRequest {
         project_id: "abcd12345678".to_string(),
-    });
+        watch_path: None,    });
     service.deprioritize_project(request).await.unwrap();
 
     let request = Request::new(ListProjectsRequest {

--- a/src/rust/daemon/grpc/src/services/project_service/tests/query_tests.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/tests/query_tests.rs
@@ -30,7 +30,8 @@ async fn test_deprioritize_project() {
 
     let request = Request::new(DeprioritizeProjectRequest {
         project_id: "abcd12345678".to_string(),
-        watch_path: None,    });
+        watch_path: None,
+    });
 
     let response = service.deprioritize_project(request).await.unwrap();
     let response = response.into_inner();
@@ -141,7 +142,8 @@ async fn test_list_projects_active_only() {
 
     let request = Request::new(DeprioritizeProjectRequest {
         project_id: "abcd12345678".to_string(),
-        watch_path: None,    });
+        watch_path: None,
+    });
     service.deprioritize_project(request).await.unwrap();
 
     let request = Request::new(ListProjectsRequest {

--- a/src/rust/daemon/grpc/src/services/project_service/worktree.rs
+++ b/src/rust/daemon/grpc/src/services/project_service/worktree.rs
@@ -1,0 +1,199 @@
+//! Worktree auto-registration and metadata lookup
+//!
+//! Handles detection and registration of git worktrees as additional watch roots
+//! for existing projects. When a session starts in a worktree whose main project
+//! is already registered, the worktree is automatically registered under the same
+//! tenant_id.
+
+use std::path::Path;
+
+use chrono::Utc;
+use tonic::Status;
+use tracing::{debug, error, info};
+use uuid::Uuid;
+
+use workspace_qdrant_core::{
+    daemon_state::WatchFolderRecord,
+    git::{detect_git_status, find_main_worktree_path, resolve_git_dir},
+    project_disambiguation::ProjectIdCalculator,
+};
+use wqm_common::constants::COLLECTION_PROJECTS;
+use wqm_common::project_id::detect_git_remote;
+
+use super::ProjectServiceImpl;
+
+/// Worktree metadata for populating response fields on existing entries.
+pub(super) struct WatchMetadata {
+    pub is_worktree: bool,
+    pub watch_path: Option<String>,
+}
+
+/// Result of a worktree auto-registration attempt.
+pub(super) enum WorktreeResult {
+    /// The path is a worktree and was successfully auto-registered.
+    Registered {
+        canonical_path: String,
+        is_high_priority: bool,
+    },
+    /// The path is not a worktree, or the main project is not registered.
+    NotApplicable,
+}
+
+impl ProjectServiceImpl {
+    /// Attempt worktree auto-registration when the project is not found.
+    ///
+    /// Checks if the path is a git worktree and whether the main working tree
+    /// is already registered. If so, creates a new watch folder entry for the
+    /// worktree that shares the same tenant_id as the main project.
+    pub(super) async fn try_worktree_auto_register(
+        &self,
+        effective_path: &Path,
+        is_high_priority: bool,
+    ) -> Result<WorktreeResult, Status> {
+        let git_status = detect_git_status(effective_path);
+        if !git_status.is_worktree {
+            return Ok(WorktreeResult::NotApplicable);
+        }
+
+        // Resolve the worktree's git directory and find the main worktree root
+        let git_dir = resolve_git_dir(effective_path).ok_or_else(|| {
+            debug!(
+                path = %effective_path.display(),
+                "Worktree detected but could not resolve git dir"
+            );
+            Status::not_found("Worktree git directory not found")
+        })?;
+
+        let main_root = match find_main_worktree_path(&git_dir) {
+            Some(p) => p,
+            None => {
+                debug!(
+                    path = %effective_path.display(),
+                    "Could not resolve main worktree path"
+                );
+                return Ok(WorktreeResult::NotApplicable);
+            }
+        };
+
+        // Compute the tenant_id for the main worktree
+        let main_remote = detect_git_remote(&main_root);
+        let calculator = ProjectIdCalculator::new();
+        let main_tenant_id = calculator.calculate(&main_root, main_remote.as_deref(), None);
+
+        // Look up the main project's watch folder by tenant_id
+        let main_record = match self.find_watch_folder_by_tenant(&main_tenant_id).await? {
+            Some(r) => r,
+            None => {
+                info!(
+                    path = %effective_path.display(),
+                    main_tenant_id = %main_tenant_id,
+                    "Worktree detected but main project not registered"
+                );
+                return Ok(WorktreeResult::NotApplicable);
+            }
+        };
+
+        // Canonicalize the worktree path
+        let canonical_path =
+            std::fs::canonicalize(effective_path).unwrap_or_else(|_| effective_path.to_path_buf());
+        let canonical_str = canonical_path.to_string_lossy().to_string();
+
+        // Create the worktree watch folder record
+        let now = Utc::now();
+        let worktree_record = WatchFolderRecord {
+            watch_id: Uuid::new_v4().to_string(),
+            path: canonical_str.clone(),
+            collection: COLLECTION_PROJECTS.to_string(),
+            tenant_id: main_tenant_id.clone(),
+            parent_watch_id: None,
+            submodule_path: None,
+            git_remote_url: main_record.git_remote_url.clone(),
+            remote_hash: main_record.remote_hash.clone(),
+            disambiguation_path: main_record.disambiguation_path.clone(),
+            is_active: is_high_priority,
+            last_activity_at: if is_high_priority { Some(now) } else { None },
+            is_paused: false,
+            pause_start_time: None,
+            is_archived: false,
+            last_commit_hash: git_status.commit_hash,
+            is_git_tracked: true,
+            is_worktree: true,
+            main_worktree_watch_id: Some(main_record.watch_id.clone()),
+            library_mode: None,
+            follow_symlinks: main_record.follow_symlinks,
+            enabled: true,
+            cleanup_on_disable: main_record.cleanup_on_disable,
+            created_at: now,
+            updated_at: now,
+            last_scan: None,
+        };
+
+        // Insert the worktree record
+        self.state_manager
+            .store_watch_folder(&worktree_record)
+            .await
+            .map_err(|e| {
+                error!("Failed to store worktree watch folder: {e}");
+                Status::internal(format!("Failed to store worktree watch folder: {e}"))
+            })?;
+
+        info!(
+            "Auto-registering worktree: {} for project {}",
+            canonical_str, main_tenant_id
+        );
+
+        Ok(WorktreeResult::Registered {
+            canonical_path: canonical_str,
+            is_high_priority,
+        })
+    }
+
+    /// Find a watch folder entry by tenant_id in the projects collection.
+    pub(super) async fn find_watch_folder_by_tenant(
+        &self,
+        tenant_id: &str,
+    ) -> Result<Option<WatchFolderRecord>, Status> {
+        self.state_manager
+            .get_watch_folder_by_tenant_id(tenant_id, COLLECTION_PROJECTS)
+            .await
+            .map_err(|e| {
+                error!("Database error looking up watch folder by tenant: {e}");
+                Status::internal(format!("Database error: {e}"))
+            })
+    }
+
+    /// Look up worktree metadata (is_worktree, watch_path) for an existing project.
+    ///
+    /// Queries the watch_folders table for the given path or tenant_id to populate
+    /// the `is_worktree` and `watch_path` response fields.
+    pub(super) async fn lookup_watch_metadata(
+        &self,
+        project_id: &str,
+        path: &str,
+    ) -> WatchMetadata {
+        let row: Option<(i32, String)> = sqlx::query_as(
+            r#"SELECT is_worktree, path FROM watch_folders
+               WHERE collection = ?1
+                 AND (path = ?2 OR tenant_id = ?3)
+               ORDER BY CASE WHEN path = ?2 THEN 0 ELSE 1 END
+               LIMIT 1"#,
+        )
+        .bind(COLLECTION_PROJECTS)
+        .bind(path)
+        .bind(project_id)
+        .fetch_optional(&self.db_pool)
+        .await
+        .unwrap_or(None);
+
+        match row {
+            Some((is_wt, watch_path)) => WatchMetadata {
+                is_worktree: is_wt != 0,
+                watch_path: Some(watch_path),
+            },
+            None => WatchMetadata {
+                is_worktree: false,
+                watch_path: None,
+            },
+        }
+    }
+}

--- a/src/rust/daemon/proto/workspace_daemon.proto
+++ b/src/rust/daemon/proto/workspace_daemon.proto
@@ -459,6 +459,8 @@ message GetProjectStatusResponse {
     google.protobuf.Timestamp last_active = 7;    // Last heartbeat/activity
     google.protobuf.Timestamp registered_at = 8;
     optional string git_remote = 9;
+    bool is_worktree = 10;                        // True if this is a worktree watch root
+    optional string main_worktree_path = 11;      // Path to the main working tree (if worktree)
 }
 
 // ListProjects Request/Response

--- a/src/rust/daemon/proto/workspace_daemon.proto
+++ b/src/rust/daemon/proto/workspace_daemon.proto
@@ -428,11 +428,14 @@ message RegisterProjectResponse {
     string priority = 3;                          // Current priority: "high", "normal", "low"
     bool is_active = 4;                           // Activity flag (spec-compliant boolean)
     bool newly_registered = 5;                    // True only if register_if_new was true and project was new
+    bool is_worktree = 6;                         // True if registered as a worktree
+    optional string watch_path = 7;               // The actual registered watch path
 }
 
 // DeprioritizeProject Request/Response
 message DeprioritizeProjectRequest {
     string project_id = 1;                        // 12-char hex identifier
+    optional string watch_path = 2;               // Absolute path to specific watch root
 }
 
 message DeprioritizeProjectResponse {
@@ -476,6 +479,7 @@ message ProjectInfo {
     string priority = 4;
     bool is_active = 5;                           // Activity flag (spec-compliant boolean)
     google.protobuf.Timestamp last_active = 6;
+    bool is_worktree = 7;                         // True if this is a worktree watch root
 }
 
 // Heartbeat Request/Response

--- a/src/typescript/mcp-server/src/clients/grpc-types-messages.ts
+++ b/src/typescript/mcp-server/src/clients/grpc-types-messages.ts
@@ -180,10 +180,13 @@ export interface RegisterProjectResponse {
   priority: string;
   is_active: boolean;
   newly_registered: boolean;
+  is_worktree?: boolean;
+  watch_path?: string;
 }
 
 export interface DeprioritizeProjectRequest {
   project_id: string;
+  watch_path?: string;
 }
 
 export interface DeprioritizeProjectResponse {
@@ -220,6 +223,7 @@ export interface ProjectInfo {
   priority: string;
   is_active: boolean;
   last_active?: { seconds: number; nanos: number };
+  is_worktree?: boolean;
 }
 
 export interface ListProjectsResponse {

--- a/src/typescript/mcp-server/src/proto/workspace_daemon.proto
+++ b/src/typescript/mcp-server/src/proto/workspace_daemon.proto
@@ -412,11 +412,14 @@ message RegisterProjectResponse {
     string priority = 3;                          // Current priority: "high", "normal", "low"
     bool is_active = 4;                           // Activity flag (spec-compliant boolean)
     bool newly_registered = 5;                    // True only if register_if_new was true and project was new
+    bool is_worktree = 6;                         // True if registered as a worktree
+    optional string watch_path = 7;               // The actual registered watch path
 }
 
 // DeprioritizeProject Request/Response
 message DeprioritizeProjectRequest {
     string project_id = 1;                        // 12-char hex identifier
+    optional string watch_path = 2;               // Absolute path to specific watch root
 }
 
 message DeprioritizeProjectResponse {
@@ -460,6 +463,7 @@ message ProjectInfo {
     string priority = 4;
     bool is_active = 5;                           // Activity flag (spec-compliant boolean)
     google.protobuf.Timestamp last_active = 6;
+    bool is_worktree = 7;                         // True if this is a worktree watch root
 }
 
 // Heartbeat Request/Response

--- a/src/typescript/mcp-server/src/server-types.ts
+++ b/src/typescript/mcp-server/src/server-types.ts
@@ -16,6 +16,9 @@ export interface SessionState {
   sessionId: string;
   projectId: string | null;
   projectPath: string | null;
+  /** Canonical watch path returned by daemon (may differ from projectPath due to symlink resolution) */
+  watchPath: string | null;
+  isWorktree: boolean;
   heartbeatInterval: ReturnType<typeof setInterval> | null;
   daemonConnected: boolean;
 }

--- a/src/typescript/mcp-server/src/server.ts
+++ b/src/typescript/mcp-server/src/server.ts
@@ -11,10 +11,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
 import type { ServerConfig } from './types/index.js';
 import { logInfo, logError, logDebug, logToolCall } from './utils/logger.js';
@@ -56,6 +53,8 @@ export class WorkspaceQdrantMcpServer {
     sessionId: '',
     projectId: null,
     projectPath: null,
+    watchPath: null,
+    isWorktree: false,
     heartbeatInterval: null,
     daemonConnected: false,
   };
@@ -72,8 +71,8 @@ export class WorkspaceQdrantMcpServer {
       {
         capabilities: { tools: {} },
         instructions: [
-          'This server provides access to the user\'s indexed codebase and knowledge libraries.',
-          'ALWAYS use the `search` tool before answering questions about the user\'s code, project structure, or library documentation.',
+          "This server provides access to the user's indexed codebase and knowledge libraries.",
+          "ALWAYS use the `search` tool before answering questions about the user's code, project structure, or library documentation.",
           'Use the `rules` tool to check for behavioral preferences before starting work.',
           'Use `retrieve` to access specific documents when you know the document ID.',
           'Use `list` to browse project file/folder structure — start with format "summary" to get an overview.',
@@ -109,7 +108,17 @@ export class WorkspaceQdrantMcpServer {
     args: Record<string, unknown> | undefined
   ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
     const startTime = Date.now();
-    const { searchTool, retrieveTool, rulesTool, storeTool, grepTool, listTool, healthMonitor, daemonClient, stateManager } = this.components;
+    const {
+      searchTool,
+      retrieveTool,
+      rulesTool,
+      storeTool,
+      grepTool,
+      listTool,
+      healthMonitor,
+      daemonClient,
+      stateManager,
+    } = this.components;
 
     // Implicit heartbeat — fire-and-forget to avoid latency
     sendHeartbeat(this.sessionState, daemonClient);
@@ -170,11 +179,8 @@ export class WorkspaceQdrantMcpServer {
         logInfo('State manager degraded', { reason: initResult.reason });
       }
 
-      await initializeSession(
-        this.sessionState,
-        daemonClient,
-        projectDetector,
-        () => startHeartbeat(this.sessionState, () => sendHeartbeat(this.sessionState, daemonClient))
+      await initializeSession(this.sessionState, daemonClient, projectDetector, () =>
+        startHeartbeat(this.sessionState, () => sendHeartbeat(this.sessionState, daemonClient))
       );
 
       healthMonitor.start();

--- a/src/typescript/mcp-server/src/session-lifecycle.ts
+++ b/src/typescript/mcp-server/src/session-lifecycle.ts
@@ -11,13 +11,7 @@ import type { ProjectDetector } from './utils/project-detector.js';
 import { getGitRemoteUrl } from './utils/project-detector.js';
 import { findGitRoot } from './utils/git-utils.js';
 import type { HealthMonitor } from './utils/health-monitor.js';
-import {
-  logInfo,
-  logError,
-  logDebug,
-  logSessionEvent,
-  logDaemonStatus,
-} from './utils/logger.js';
+import { logInfo, logError, logDebug, logSessionEvent, logDaemonStatus } from './utils/logger.js';
 import { HEARTBEAT_INTERVAL_MS } from './server-types.js';
 import type { SessionState } from './server-types.js';
 
@@ -112,6 +106,14 @@ export async function registerProject(
       logDebug('Project ID assigned by daemon', { project_id: response.project_id });
     }
 
+    if (response.is_worktree) {
+      logInfo('Registered as worktree', {
+        project_path: sessionState.projectPath,
+        project_id: response.project_id,
+        watch_path: response.watch_path,
+      });
+    }
+
     logSessionEvent('register', {
       project_id: response.project_id,
       project_path: sessionState.projectPath,
@@ -119,6 +121,8 @@ export async function registerProject(
       priority: response.priority,
       is_active: response.is_active,
       newly_registered: response.newly_registered,
+      is_worktree: response.is_worktree,
+      watch_path: response.watch_path,
     });
   } catch (error) {
     logError('Failed to register project', error, {
@@ -192,10 +196,7 @@ export async function registerProjectFromTool(
 /**
  * Start the heartbeat interval. Mutates sessionState in place.
  */
-export function startHeartbeat(
-  sessionState: SessionState,
-  sendHeartbeatFn: () => void
-): void {
+export function startHeartbeat(sessionState: SessionState, sendHeartbeatFn: () => void): void {
   if (sessionState.heartbeatInterval) {
     clearInterval(sessionState.heartbeatInterval);
   }
@@ -259,8 +260,10 @@ export async function cleanup(
 
   if (sessionState.projectId && sessionState.daemonConnected) {
     try {
+      const projectId = sessionState.projectId!;
       const response = await daemonClient.deprioritizeProject({
-        project_id: sessionState.projectId,
+        project_id: projectId,
+        ...(sessionState.projectPath ? { watch_path: sessionState.projectPath } : {}),
       });
       logSessionEvent('deprioritize', {
         project_id: sessionState.projectId,

--- a/src/typescript/mcp-server/src/session-lifecycle.ts
+++ b/src/typescript/mcp-server/src/session-lifecycle.ts
@@ -107,10 +107,12 @@ export async function registerProject(
     }
 
     if (response.is_worktree) {
+      sessionState.isWorktree = true;
+      sessionState.watchPath = response.watch_path ?? sessionState.projectPath;
       logInfo('Registered as worktree', {
         project_path: sessionState.projectPath,
         project_id: response.project_id,
-        watch_path: response.watch_path,
+        watch_path: sessionState.watchPath,
       });
     }
 
@@ -263,7 +265,9 @@ export async function cleanup(
       const projectId = sessionState.projectId!;
       const response = await daemonClient.deprioritizeProject({
         project_id: projectId,
-        ...(sessionState.projectPath ? { watch_path: sessionState.projectPath } : {}),
+        ...(sessionState.isWorktree && sessionState.watchPath
+          ? { watch_path: sessionState.watchPath }
+          : {}),
       });
       logSessionEvent('deprioritize', {
         project_id: sessionState.projectId,

--- a/src/typescript/mcp-server/tests/clients/sqlite-state-manager-projects.test.ts
+++ b/src/typescript/mcp-server/tests/clients/sqlite-state-manager-projects.test.ts
@@ -125,13 +125,15 @@ describe('SqliteStateManager', () => {
     it('should return longest match when multiple projects match', () => {
       // Insert a parent project
       const db2 = new Database(dbPath);
-      db2.prepare(
-        `
+      db2
+        .prepare(
+          `
         INSERT INTO watch_folders
         (watch_id, path, collection, tenant_id, is_active, created_at, updated_at)
         VALUES ('watch-parent', '/test', 'projects', 'parent000000', 1, datetime('now'), datetime('now'))
       `
-      ).run();
+        )
+        .run();
       db2.close();
 
       const result = manager.getProjectByPath('/test/project/src');
@@ -165,6 +167,68 @@ describe('SqliteStateManager', () => {
       expect(result.status).toBe('ok');
       expect(result.data).toHaveLength(1);
       expect(result.data[0].project_id).toBe('abc123456789');
+    });
+  });
+
+  // T-13: getProjectByPath returns correct result for a registered worktree
+  describe('worktree project lookup', () => {
+    let manager: SqliteStateManager;
+
+    beforeEach(() => {
+      const db = new Database(dbPath);
+
+      // Add is_worktree column as the daemon does via migration
+      db.exec('ALTER TABLE watch_folders ADD COLUMN is_worktree INTEGER DEFAULT 0');
+
+      // Insert the main project
+      db.prepare(
+        `INSERT INTO watch_folders
+         (watch_id, path, collection, tenant_id, is_active, is_worktree, created_at, updated_at)
+         VALUES ('watch-main', '/repos/main-project', 'projects', 'main0000000000', 1, 0,
+                 datetime('now'), datetime('now'))`
+      ).run();
+
+      // Insert a worktree entry pointing to a different directory
+      db.prepare(
+        `INSERT INTO watch_folders
+         (watch_id, path, collection, tenant_id, is_active, is_worktree, created_at, updated_at)
+         VALUES ('watch-wt', '/repos/worktrees/feature-branch', 'projects', 'worktreeid0000', 1, 1,
+                 datetime('now'), datetime('now'))`
+      ).run();
+
+      db.close();
+
+      manager = new SqliteStateManager({ dbPath });
+      manager.initialize();
+    });
+
+    afterEach(() => {
+      manager.close();
+    });
+
+    it('should return the worktree project_id when queried by worktree path', () => {
+      const result = manager.getProjectByPath('/repos/worktrees/feature-branch');
+
+      expect(result.status).toBe('ok');
+      expect(result.data).not.toBeNull();
+      expect(result.data!.project_id).toBe('worktreeid0000');
+      expect(result.data!.project_path).toBe('/repos/worktrees/feature-branch');
+    });
+
+    it('should not confuse worktree with main project when paths differ', () => {
+      const mainResult = manager.getProjectByPath('/repos/main-project');
+      const worktreeResult = manager.getProjectByPath('/repos/worktrees/feature-branch');
+
+      expect(mainResult.data!.project_id).toBe('main0000000000');
+      expect(worktreeResult.data!.project_id).toBe('worktreeid0000');
+    });
+
+    it('should match a subdirectory of the worktree path', () => {
+      const result = manager.getProjectByPath('/repos/worktrees/feature-branch/src/lib');
+
+      expect(result.status).toBe('ok');
+      expect(result.data).not.toBeNull();
+      expect(result.data!.project_id).toBe('worktreeid0000');
     });
   });
 

--- a/src/typescript/mcp-server/tests/server-daemon-lifecycle.test.ts
+++ b/src/typescript/mcp-server/tests/server-daemon-lifecycle.test.ts
@@ -161,11 +161,13 @@ describe('Session lifecycle with connected daemon', () => {
 
     const dbPath = join(tempDir, 'state.db');
     const db = new Database(dbPath);
-    db.prepare(`
+    db.prepare(
+      `
       INSERT INTO watch_folders
       (watch_id, path, collection, tenant_id, is_active, created_at, updated_at)
       VALUES ('watch-1', ?, 'projects', 'abc123456789', 1, datetime('now'), datetime('now'))
-    `).run(realProjectPath);
+    `
+    ).run(realProjectPath);
     db.close();
 
     const originalCwd = process.cwd();
@@ -194,6 +196,135 @@ describe('Session lifecycle with connected daemon', () => {
       expect(mockInstance.deprioritizeProject).toHaveBeenCalledWith({
         project_id: 'abc123456789',
       });
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  // T-14: cleanup sends watch_path in DeprioritizeProject call
+  it('should send watch_path in deprioritizeProject call on cleanup', async () => {
+    const { DaemonClient } = await import('../src/clients/daemon-client.js');
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn(),
+      isConnected: vi.fn().mockReturnValue(true),
+      registerProject: vi.fn().mockResolvedValue({
+        created: false,
+        project_id: 'proj-with-path',
+        priority: 'high',
+        is_active: true,
+        newly_registered: false,
+      }),
+      deprioritizeProject: vi.fn().mockResolvedValue({
+        success: true,
+        is_active: false,
+        new_priority: 'normal',
+      }),
+      heartbeat: vi.fn().mockResolvedValue({ acknowledged: true }),
+    };
+    vi.mocked(DaemonClient).mockImplementation(
+      () => mockInstance as unknown as InstanceType<typeof DaemonClient>
+    );
+
+    const projectPath = join(tempDir, 'path-project');
+    mkdirSync(projectPath);
+    mkdirSync(join(projectPath, '.git'));
+    const realProjectPath = realpathSync(projectPath);
+
+    const db = new Database(join(tempDir, 'state.db'));
+    db.prepare(
+      `
+      INSERT INTO watch_folders
+      (watch_id, path, collection, tenant_id, is_active, created_at, updated_at)
+      VALUES ('watch-path', ?, 'projects', 'proj-with-path', 1, datetime('now'), datetime('now'))
+    `
+    ).run(realProjectPath);
+    db.close();
+
+    const originalCwd = process.cwd();
+    process.chdir(projectPath);
+
+    try {
+      const server = new WorkspaceQdrantMcpServer({ config, stdio: false });
+      await server.start();
+
+      const state = server.getSessionState();
+      expect(state.projectPath).toBe(realProjectPath);
+
+      await server.stop();
+
+      // watch_path must be included in the deprioritizeProject call
+      expect(mockInstance.deprioritizeProject).toHaveBeenCalledWith({
+        project_id: 'proj-with-path',
+        watch_path: realProjectPath,
+      });
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  // T-15: session initialization in a worktree correctly sets projectPath
+  it('should set projectPath to the worktree directory on initialization', async () => {
+    const { DaemonClient } = await import('../src/clients/daemon-client.js');
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn(),
+      isConnected: vi.fn().mockReturnValue(true),
+      registerProject: vi.fn().mockResolvedValue({
+        created: false,
+        project_id: 'worktree-proj-id',
+        priority: 'high',
+        is_active: true,
+        newly_registered: false,
+        is_worktree: true,
+        watch_path: realTempDir,
+      }),
+      deprioritizeProject: vi.fn().mockResolvedValue({
+        success: true,
+        is_active: false,
+        new_priority: 'normal',
+      }),
+      heartbeat: vi.fn().mockResolvedValue({ acknowledged: true }),
+    };
+    vi.mocked(DaemonClient).mockImplementation(
+      () => mockInstance as unknown as InstanceType<typeof DaemonClient>
+    );
+
+    // Set up a worktree: .git is a FILE (pointer), not a directory
+    const worktreePath = join(tempDir, 'feature-worktree');
+    mkdirSync(worktreePath);
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(
+      join(worktreePath, '.git'),
+      `gitdir: ${join(realTempDir, '.git', 'worktrees', 'feature-worktree')}\n`
+    );
+    const realWorktreePath = realpathSync(worktreePath);
+
+    // Register the worktree path in the database as if the daemon did it
+    const db = new Database(join(tempDir, 'state.db'));
+    db.exec('ALTER TABLE watch_folders ADD COLUMN is_worktree INTEGER DEFAULT 0');
+    db.prepare(
+      `
+      INSERT INTO watch_folders
+      (watch_id, path, collection, tenant_id, is_active, is_worktree, created_at, updated_at)
+      VALUES ('watch-wt', ?, 'projects', 'worktree-proj-id', 1, 1, datetime('now'), datetime('now'))
+    `
+    ).run(realWorktreePath);
+    db.close();
+
+    const originalCwd = process.cwd();
+    process.chdir(worktreePath);
+
+    try {
+      const server = new WorkspaceQdrantMcpServer({ config, stdio: false });
+      await server.start();
+
+      const state = server.getSessionState();
+      // The session must record the worktree directory, not the main repo
+      expect(state.projectPath).toBe(realWorktreePath);
+      expect(state.projectId).toBe('worktree-proj-id');
+
+      await server.stop();
     } finally {
       process.chdir(originalCwd);
     }

--- a/src/typescript/mcp-server/tests/server-daemon-lifecycle.test.ts
+++ b/src/typescript/mcp-server/tests/server-daemon-lifecycle.test.ts
@@ -208,13 +208,7 @@ describe('Session lifecycle with connected daemon', () => {
       connect: vi.fn().mockResolvedValue(undefined),
       close: vi.fn(),
       isConnected: vi.fn().mockReturnValue(true),
-      registerProject: vi.fn().mockResolvedValue({
-        created: false,
-        project_id: 'proj-with-path',
-        priority: 'high',
-        is_active: true,
-        newly_registered: false,
-      }),
+      registerProject: vi.fn(), // configured below after realProjectPath is known
       deprioritizeProject: vi.fn().mockResolvedValue({
         success: true,
         is_active: false,
@@ -230,6 +224,17 @@ describe('Session lifecycle with connected daemon', () => {
     mkdirSync(projectPath);
     mkdirSync(join(projectPath, '.git'));
     const realProjectPath = realpathSync(projectPath);
+
+    // Configure registerProject mock now that realProjectPath is known
+    mockInstance.registerProject.mockResolvedValue({
+      created: false,
+      project_id: 'proj-with-path',
+      priority: 'high',
+      is_active: true,
+      newly_registered: false,
+      is_worktree: true,
+      watch_path: realProjectPath,
+    });
 
     const db = new Database(join(tempDir, 'state.db'));
     db.prepare(


### PR DESCRIPTION
## Summary

- Worktrees are automatically registered as additional watch roots for the same project when a session starts in a worktree directory — no manual setup needed
- Each worktree gets its own `watch_folders` entry sharing the parent project's `tenant_id`, with independent `is_active` reference counting
- Path-scoped deactivation ensures closing a worktree session doesn't affect the main repo or other worktrees

## Changes

### Data model (schema v31)
- Added `is_worktree` and `main_worktree_watch_id` columns to `watch_folders`
- Updated `WatchFolderRecord` struct and all CRUD operations

### Daemon
- New `git/worktree.rs` module with `find_main_worktree_path()` utility
- Queue processor detects worktrees at registration time
- `RegisterProject` gRPC handler auto-registers worktrees when main project exists
- `DeprioritizeProject` supports path-scoped deactivation via new `watch_path` field

### CLI
- `wqm project list` shows `[worktree]` indicator
- `wqm project add` notes worktree status on registration
- `wqm project info` displays main working tree path

### MCP server
- `cleanup()` sends `watch_path` for path-scoped deactivation
- Logs worktree auto-registration events

### Proto
- `DeprioritizeProjectRequest`: added optional `watch_path` (field 2)
- `RegisterProjectResponse`: added `is_worktree` (field 6), `watch_path` (field 7)
- `ProjectInfo`: added `is_worktree` (field 7)
- `GetProjectStatusResponse`: added `is_worktree` (field 10), `main_worktree_path` (field 11)

## Test plan

- [x] 2142 Rust unit tests pass (11 new worktree-specific tests)
- [x] 5 new path-scoped deactivation tests
- [x] 6 new worktree integration tests (registration, concurrent activation, metadata persistence)
- [x] TypeScript tests for project lookup, cleanup watch_path, and session initialization
- [x] Release build succeeds for daemon and CLI
- [x] Daemon starts healthy after deploy
- [ ] Manual: open Claude Code in a git worktree of a registered project, verify auto-registration
- [ ] Manual: `wqm project list` shows worktree entries correctly
- [ ] Manual: closing worktree session doesn't deactivate main repo