### PR TITLE
feat: failed queue state hardening and idle maintenance scheduler

### DIFF
--- a/src/rust/cli/src/commands/queue/drop.rs
+++ b/src/rust/cli/src/commands/queue/drop.rs
@@ -1,0 +1,136 @@
+//! Queue drop subcommand — remove failed items from the queue.
+
+use anyhow::Result;
+use rusqlite::params;
+
+use crate::output;
+
+use super::db::connect_readwrite;
+
+pub async fn execute(
+    queue_id: Option<String>,
+    all_permanent: bool,
+    all_stale: bool,
+    yes: bool,
+) -> Result<()> {
+    if !all_permanent && !all_stale && queue_id.is_none() {
+        anyhow::bail!("Specify a queue_id, --all-permanent, or --all-stale");
+    }
+
+    let conn = connect_readwrite()?;
+
+    if all_permanent {
+        drop_all_permanent(&conn, yes)
+    } else if all_stale {
+        drop_all_stale(&conn, yes)
+    } else {
+        drop_one(&conn, &queue_id.unwrap())
+    }
+}
+
+fn drop_all_permanent(conn: &rusqlite::Connection, yes: bool) -> Result<()> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM unified_queue WHERE status = 'failed' \
+         AND (error_message LIKE '[permanent_%' OR error_message LIKE '[permanent_exhausted]%')",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if count == 0 {
+        output::success("No permanently failed items to drop");
+        return Ok(());
+    }
+
+    if !yes {
+        output::warning(format!(
+            "This will remove {} permanently failed item(s). Use -y to confirm.",
+            count
+        ));
+        return Ok(());
+    }
+
+    let deleted = conn.execute(
+        "DELETE FROM unified_queue WHERE status = 'failed' \
+         AND (error_message LIKE '[permanent_%' OR error_message LIKE '[permanent_exhausted]%')",
+        [],
+    )?;
+
+    output::success(format!("Dropped {} permanently failed item(s)", deleted));
+    Ok(())
+}
+
+fn drop_all_stale(conn: &rusqlite::Connection, yes: bool) -> Result<()> {
+    // Find failed file items where the file no longer exists on disk
+    let mut stmt = conn.prepare(
+        "SELECT queue_id, file_path FROM unified_queue \
+         WHERE status = 'failed' AND item_type = 'file' AND file_path IS NOT NULL",
+    )?;
+
+    let stale_ids: Vec<String> = stmt
+        .query_map([], |row| {
+            let queue_id: String = row.get(0)?;
+            let file_path: String = row.get(1)?;
+            Ok((queue_id, file_path))
+        })?
+        .filter_map(|r| r.ok())
+        .filter(|(_, path)| !std::path::Path::new(path).exists())
+        .map(|(id, _)| id)
+        .collect();
+
+    if stale_ids.is_empty() {
+        output::success("No stale failed items to drop");
+        return Ok(());
+    }
+
+    if !yes {
+        output::warning(format!(
+            "This will remove {} stale failed item(s) (files no longer on disk). Use -y to confirm.",
+            stale_ids.len()
+        ));
+        return Ok(());
+    }
+
+    let mut deleted = 0;
+    for id in &stale_ids {
+        deleted += conn.execute("DELETE FROM unified_queue WHERE queue_id = ?1", params![id])?;
+    }
+
+    output::success(format!("Dropped {} stale failed item(s)", deleted));
+    Ok(())
+}
+
+fn drop_one(conn: &rusqlite::Connection, id: &str) -> Result<()> {
+    let prefix = format!("{}%", id);
+
+    let result: std::result::Result<(String, String), _> = conn.query_row(
+        "SELECT queue_id, status FROM unified_queue \
+         WHERE queue_id = ?1 OR queue_id LIKE ?2 LIMIT 1",
+        params![id, &prefix],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    );
+
+    match result {
+        Ok((found_id, status)) => {
+            if status != "failed" {
+                output::warning(format!(
+                    "Item {} has status '{}', not 'failed'. Only failed items can be dropped.",
+                    found_id, status
+                ));
+                return Ok(());
+            }
+
+            conn.execute(
+                "DELETE FROM unified_queue WHERE queue_id = ?1",
+                params![&found_id],
+            )?;
+
+            output::success(format!("Dropped failed item {}", found_id));
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            output::error(format!("Queue item not found: {}", id));
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    Ok(())
+}

--- a/src/rust/cli/src/commands/queue/mod.rs
+++ b/src/rust/cli/src/commands/queue/mod.rs
@@ -6,6 +6,7 @@
 mod cancel;
 mod clean;
 mod db;
+mod drop;
 pub mod formatters;
 mod list;
 mod remove;
@@ -119,6 +120,10 @@ enum QueueCommand {
         /// Retry all failed items
         #[arg(long)]
         all: bool,
+
+        /// Retry only transient failed items (clears resurrection count)
+        #[arg(long)]
+        all_transient: bool,
     },
 
     /// Clean old completed or failed queue items
@@ -140,6 +145,24 @@ enum QueueCommand {
     Remove {
         /// Queue ID or ID prefix
         queue_id: String,
+    },
+
+    /// Drop failed items from the queue
+    Drop {
+        /// Queue ID to drop (omit for bulk operations)
+        queue_id: Option<String>,
+
+        /// Drop all permanently failed items ([permanent_*] prefix)
+        #[arg(long)]
+        all_permanent: bool,
+
+        /// Drop all stale items (files no longer on disk)
+        #[arg(long)]
+        all_stale: bool,
+
+        /// Skip confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
     },
 
     /// Cancel all pending (or failed) queue items for a project
@@ -193,9 +216,19 @@ pub async fn execute(args: QueueArgs) -> Result<()> {
             by_op,
             by_collection,
         } => stats::execute(json, by_type, by_op, by_collection).await,
-        QueueCommand::Retry { queue_id, all } => retry::execute(queue_id, all).await,
+        QueueCommand::Retry {
+            queue_id,
+            all,
+            all_transient,
+        } => retry::execute(queue_id, all, all_transient).await,
         QueueCommand::Clean { days, status, yes } => clean::execute(days, status, yes).await,
         QueueCommand::Remove { queue_id } => remove::execute(&queue_id).await,
+        QueueCommand::Drop {
+            queue_id,
+            all_permanent,
+            all_stale,
+            yes,
+        } => drop::execute(queue_id, all_permanent, all_stale, yes).await,
         QueueCommand::Cancel {
             project,
             status,

--- a/src/rust/cli/src/commands/queue/retry.rs
+++ b/src/rust/cli/src/commands/queue/retry.rs
@@ -7,15 +7,17 @@ use crate::output;
 
 use super::db::connect_readwrite;
 
-pub async fn execute(queue_id: Option<String>, all: bool) -> Result<()> {
-    if !all && queue_id.is_none() {
-        anyhow::bail!("Specify a queue_id or use --all to retry all failed items");
+pub async fn execute(queue_id: Option<String>, all: bool, all_transient: bool) -> Result<()> {
+    if !all && !all_transient && queue_id.is_none() {
+        anyhow::bail!("Specify a queue_id, --all, or --all-transient to retry failed items");
     }
 
     let conn = connect_readwrite()?;
 
     if all {
         retry_all(&conn)
+    } else if all_transient {
+        retry_all_transient(&conn)
     } else {
         retry_one(&conn, &queue_id.unwrap())
     }
@@ -52,10 +54,48 @@ fn retry_all(conn: &rusqlite::Connection) -> Result<()> {
     Ok(())
 }
 
+fn retry_all_transient(conn: &rusqlite::Connection) -> Result<()> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM unified_queue WHERE status = 'failed' \
+         AND error_message LIKE '[transient_%'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if count == 0 {
+        output::success("No transient failed items to retry");
+        return Ok(());
+    }
+
+    // Reset status and also clear resurrection_count in metadata
+    let updated = conn.execute(
+        r#"
+        UPDATE unified_queue
+        SET status = 'pending',
+            retry_count = 0,
+            error_message = NULL,
+            last_error_at = NULL,
+            lease_until = NULL,
+            worker_id = NULL,
+            metadata = json_set(COALESCE(metadata, '{}'), '$.resurrection_count', 0),
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        WHERE status = 'failed'
+          AND error_message LIKE '[transient_%'
+        "#,
+        [],
+    )?;
+
+    output::success(format!(
+        "Reset {} transient failed items to pending (resurrection count cleared)",
+        updated
+    ));
+    Ok(())
+}
+
 fn retry_one(conn: &rusqlite::Connection, id: &str) -> Result<()> {
     let prefix = format!("{}%", id);
 
-    let result: Result<(String, String, i32), _> = conn.query_row(
+    let result: std::result::Result<(String, String, i32), _> = conn.query_row(
         "SELECT queue_id, status, retry_count FROM unified_queue \
          WHERE queue_id = ?1 OR queue_id LIKE ?2 LIMIT 1",
         params![id, &prefix],
@@ -82,6 +122,7 @@ fn retry_one(conn: &rusqlite::Connection, id: &str) -> Result<()> {
                     last_error_at = NULL,
                     lease_until = NULL,
                     worker_id = NULL,
+                    metadata = json_set(COALESCE(metadata, '{}'), '$.resurrection_count', 0),
                     updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
                 WHERE queue_id = ?1
                 "#,

--- a/src/rust/daemon/core/src/idle/mod.rs
+++ b/src/rust/daemon/core/src/idle/mod.rs
@@ -1,0 +1,102 @@
+//! Idle state taxonomy and maintenance scheduler.
+//!
+//! Formalizes the daemon's idle states and provides a framework for running
+//! maintenance tasks (orphan cleanup, filesystem reconciliation, etc.) during
+//! idle periods with automatic yield when real work arrives.
+
+mod scheduler;
+mod task;
+
+pub mod tasks;
+
+pub use scheduler::{MaintenanceScheduler, MaintenanceTaskStatus};
+pub use task::{MaintenanceContext, MaintenanceResult, MaintenanceTask};
+
+/// What the daemon can do right now.
+///
+/// Determined each loop iteration based on queue depth, Qdrant availability,
+/// and memory pressure. Maintenance tasks declare which states they can run in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdleState {
+    /// Queue empty, Qdrant available — full maintenance window.
+    FullIdle,
+    /// Queue has items but Qdrant circuit is open — SQLite+filesystem only.
+    QdrantDownIdle,
+    /// Under memory pressure — light bookkeeping only.
+    ResourceConstrained,
+    /// Actively processing queue items.
+    Active,
+}
+
+impl IdleState {
+    /// Determine the current idle state from system conditions.
+    pub fn determine(queue_depth: i64, qdrant_available: bool, memory_pressure: bool) -> Self {
+        if memory_pressure {
+            return IdleState::ResourceConstrained;
+        }
+        if queue_depth > 0 && qdrant_available {
+            return IdleState::Active;
+        }
+        if !qdrant_available {
+            return IdleState::QdrantDownIdle;
+        }
+        IdleState::FullIdle
+    }
+
+    /// Can any maintenance task run in this state?
+    pub fn allows_maintenance(&self) -> bool {
+        !matches!(self, IdleState::Active)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_full_idle() {
+        assert_eq!(IdleState::determine(0, true, false), IdleState::FullIdle);
+    }
+
+    #[test]
+    fn test_active_when_work_and_qdrant() {
+        assert_eq!(IdleState::determine(10, true, false), IdleState::Active);
+    }
+
+    #[test]
+    fn test_qdrant_down_idle() {
+        assert_eq!(
+            IdleState::determine(5, false, false),
+            IdleState::QdrantDownIdle
+        );
+    }
+
+    #[test]
+    fn test_qdrant_down_empty_queue() {
+        // Queue empty but Qdrant down — can still do SQLite maintenance
+        assert_eq!(
+            IdleState::determine(0, false, false),
+            IdleState::QdrantDownIdle
+        );
+    }
+
+    #[test]
+    fn test_memory_pressure_overrides() {
+        assert_eq!(
+            IdleState::determine(0, true, true),
+            IdleState::ResourceConstrained
+        );
+        assert_eq!(
+            IdleState::determine(10, true, true),
+            IdleState::ResourceConstrained
+        );
+    }
+
+    #[test]
+    fn test_allows_maintenance() {
+        assert!(IdleState::FullIdle.allows_maintenance());
+        assert!(IdleState::QdrantDownIdle.allows_maintenance());
+        assert!(IdleState::ResourceConstrained.allows_maintenance());
+        assert!(!IdleState::Active.allows_maintenance());
+    }
+}

--- a/src/rust/daemon/core/src/idle/scheduler.rs
+++ b/src/rust/daemon/core/src/idle/scheduler.rs
@@ -1,0 +1,159 @@
+//! Maintenance scheduler — runs eligible tasks during idle periods.
+
+use std::time::Instant;
+
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
+use super::task::{MaintenanceContext, MaintenanceResult, MaintenanceTask};
+use super::IdleState;
+
+/// Execution state for a registered task.
+struct RegisteredTask {
+    task: Box<dyn MaintenanceTask>,
+    last_run: Option<Instant>,
+    in_progress: bool,
+}
+
+/// Status snapshot of a registered maintenance task (for CLI/gRPC).
+#[derive(Debug, Clone)]
+pub struct MaintenanceTaskStatus {
+    pub name: String,
+    pub in_progress: bool,
+    pub last_run_secs_ago: Option<u64>,
+}
+
+/// Scheduler that manages and executes maintenance tasks during idle periods.
+///
+/// Call `tick()` each processing-loop iteration when idle. The scheduler picks
+/// the first eligible task, runs one batch, and returns. When real work arrives,
+/// call `cancel_active()` so the running batch can yield.
+pub struct MaintenanceScheduler {
+    tasks: Vec<RegisteredTask>,
+    active_task_idx: Option<usize>,
+    current_cancel: Option<CancellationToken>,
+}
+
+impl MaintenanceScheduler {
+    pub fn new() -> Self {
+        Self {
+            tasks: Vec::new(),
+            active_task_idx: None,
+            current_cancel: None,
+        }
+    }
+
+    /// Register a maintenance task.
+    pub fn register(&mut self, task: Box<dyn MaintenanceTask>) {
+        info!("Registered maintenance task: {}", task.name());
+        self.tasks.push(RegisteredTask {
+            task,
+            last_run: None,
+            in_progress: false,
+        });
+    }
+
+    /// Number of registered tasks.
+    pub fn task_count(&self) -> usize {
+        self.tasks.len()
+    }
+
+    /// Cancel the currently running batch so it yields promptly.
+    pub fn cancel_active(&mut self) {
+        if let Some(token) = self.current_cancel.take() {
+            token.cancel();
+        }
+    }
+
+    /// Run one tick of the scheduler. Returns `true` if a task batch ran.
+    ///
+    /// - Resumes an in-progress (yielded) task before considering new ones.
+    /// - Picks the first eligible task based on idle state, delay, and cooldown.
+    /// - Runs exactly one `run_batch()` call, then returns.
+    pub async fn tick(
+        &mut self,
+        idle_state: IdleState,
+        idle_elapsed_secs: u64,
+        ctx: &MaintenanceContext<'_>,
+    ) -> bool {
+        // Resume in-progress task first
+        if let Some(idx) = self.active_task_idx {
+            let reg = &self.tasks[idx];
+            if reg.task.can_run_in(idle_state) {
+                return self.run_task_batch(idx, ctx).await;
+            }
+            // Idle state changed and task can no longer run — park it
+            debug!(
+                "Maintenance task '{}' parked: idle state changed to {:?}",
+                reg.task.name(),
+                idle_state
+            );
+            return false;
+        }
+
+        // Find next eligible task
+        let now = Instant::now();
+        for idx in 0..self.tasks.len() {
+            let reg = &self.tasks[idx];
+            if !reg.task.can_run_in(idle_state) {
+                continue;
+            }
+            if idle_elapsed_secs < reg.task.idle_delay_secs() {
+                continue;
+            }
+            if let Some(last) = reg.last_run {
+                if now.duration_since(last).as_secs() < reg.task.cooldown_secs() {
+                    continue;
+                }
+            }
+            return self.run_task_batch(idx, ctx).await;
+        }
+        false
+    }
+
+    /// Run a single batch of the task at `idx`.
+    async fn run_task_batch(&mut self, idx: usize, ctx: &MaintenanceContext<'_>) -> bool {
+        let cancel = CancellationToken::new();
+        self.current_cancel = Some(cancel.clone());
+
+        let reg = &mut self.tasks[idx];
+        if !reg.in_progress {
+            info!("Starting maintenance: {}", reg.task.name());
+            reg.in_progress = true;
+            reg.task.reset();
+        }
+
+        let result = reg.task.run_batch(ctx, &cancel).await;
+        self.current_cancel = None;
+
+        match result {
+            MaintenanceResult::Continue => {
+                self.active_task_idx = Some(idx);
+            }
+            MaintenanceResult::Done => {
+                info!("Maintenance complete: {}", reg.task.name());
+                reg.in_progress = false;
+                reg.last_run = Some(Instant::now());
+                self.active_task_idx = None;
+            }
+            MaintenanceResult::Yielded => {
+                debug!("Maintenance yielded: {} (will resume)", reg.task.name());
+                self.active_task_idx = Some(idx);
+            }
+        }
+        true
+    }
+
+    /// Snapshot of all registered tasks for observability.
+    pub fn status(&self) -> Vec<MaintenanceTaskStatus> {
+        let now = Instant::now();
+        self.tasks
+            .iter()
+            .map(|reg| MaintenanceTaskStatus {
+                name: reg.task.name().to_string(),
+                in_progress: reg.in_progress,
+                last_run_secs_ago: reg.last_run.map(|t| now.duration_since(t).as_secs()),
+            })
+            .collect()
+    }
+}

--- a/src/rust/daemon/core/src/idle/task.rs
+++ b/src/rust/daemon/core/src/idle/task.rs
@@ -1,0 +1,67 @@
+//! MaintenanceTask trait and supporting types.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+use super::IdleState;
+use crate::queue_operations::QueueManager;
+use crate::search_db::SearchDbManager;
+use crate::storage::StorageClient;
+
+/// Result of a single maintenance batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaintenanceResult {
+    /// More work to do — call `run_batch` again on the next idle window.
+    Continue,
+    /// All work complete for this cycle.
+    Done,
+    /// Interrupted by cancellation — progress saved internally.
+    Yielded,
+}
+
+/// Shared references provided to each maintenance task.
+pub struct MaintenanceContext<'a> {
+    pub pool: &'a sqlx::SqlitePool,
+    pub storage_client: &'a Arc<StorageClient>,
+    pub search_db: Option<&'a Arc<SearchDbManager>>,
+    pub queue_manager: &'a QueueManager,
+}
+
+/// A maintenance task that runs during idle periods.
+///
+/// Implementations must be resumable: `run_batch` processes a fixed-size
+/// chunk of work, then returns `Continue` (more to do), `Done` (finished),
+/// or `Yielded` (cancelled mid-batch). The scheduler calls `run_batch`
+/// repeatedly across idle windows until `Done`.
+#[async_trait]
+pub trait MaintenanceTask: Send + Sync {
+    /// Human-readable name for logging.
+    fn name(&self) -> &str;
+
+    /// Which idle states this task can run in.
+    fn required_idle_states(&self) -> &[IdleState];
+
+    /// Minimum seconds of continuous idle before this task activates.
+    fn idle_delay_secs(&self) -> u64;
+
+    /// Minimum seconds between full cycles (cooldown after `Done`).
+    fn cooldown_secs(&self) -> u64;
+
+    /// Run one batch. Check `cancel.is_cancelled()` between items to yield
+    /// promptly when real work arrives.
+    async fn run_batch(
+        &mut self,
+        ctx: &MaintenanceContext<'_>,
+        cancel: &CancellationToken,
+    ) -> MaintenanceResult;
+
+    /// Check if this task can run in the given idle state.
+    fn can_run_in(&self, state: IdleState) -> bool {
+        self.required_idle_states().contains(&state)
+    }
+
+    /// Reset internal progress for a new cycle (called before first batch).
+    fn reset(&mut self) {}
+}

--- a/src/rust/daemon/core/src/idle/tasks/filesystem_reconcile.rs
+++ b/src/rust/daemon/core/src/idle/tasks/filesystem_reconcile.rs
@@ -1,0 +1,141 @@
+//! Filesystem reconciliation — detect tracked files that no longer exist on
+//! disk and enqueue delete operations to clean them up.
+
+use async_trait::async_trait;
+use sqlx::Row;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::idle::task::{MaintenanceContext, MaintenanceResult, MaintenanceTask};
+use crate::idle::IdleState;
+use crate::unified_queue_schema::{ItemType, QueueOperation};
+
+/// Batch-checks tracked files against the filesystem.
+///
+/// Runs in `FullIdle` or `QdrantDownIdle` (only needs disk + SQLite).
+/// Missing files get a delete operation enqueued so the normal pipeline
+/// handles Qdrant cleanup when available.
+pub struct FilesystemReconcileTask {
+    batch_size: i64,
+    offset: i64,
+    total_checked: u64,
+    files_missing: u64,
+}
+
+impl FilesystemReconcileTask {
+    pub fn new() -> Self {
+        Self {
+            batch_size: 100,
+            offset: 0,
+            total_checked: 0,
+            files_missing: 0,
+        }
+    }
+}
+
+#[async_trait]
+impl MaintenanceTask for FilesystemReconcileTask {
+    fn name(&self) -> &str {
+        "filesystem_reconcile"
+    }
+
+    fn required_idle_states(&self) -> &[IdleState] {
+        &[IdleState::FullIdle, IdleState::QdrantDownIdle]
+    }
+
+    fn idle_delay_secs(&self) -> u64 {
+        60
+    }
+
+    fn cooldown_secs(&self) -> u64 {
+        1800 // 30 minutes
+    }
+
+    fn reset(&mut self) {
+        self.offset = 0;
+        self.total_checked = 0;
+        self.files_missing = 0;
+    }
+
+    async fn run_batch(
+        &mut self,
+        ctx: &MaintenanceContext<'_>,
+        cancel: &CancellationToken,
+    ) -> MaintenanceResult {
+        let rows = sqlx::query(
+            "SELECT tf.file_id, tf.file_path, tf.branch, tf.collection,
+                    wf.tenant_id
+             FROM tracked_files tf
+             JOIN watch_folders wf ON tf.watch_folder_id = wf.id
+             ORDER BY tf.file_id
+             LIMIT ?1 OFFSET ?2",
+        )
+        .bind(self.batch_size)
+        .bind(self.offset)
+        .fetch_all(ctx.pool)
+        .await
+        .unwrap_or_default();
+
+        if rows.is_empty() {
+            if self.files_missing > 0 {
+                info!(
+                    "Filesystem reconcile complete: checked={}, missing={}",
+                    self.total_checked, self.files_missing
+                );
+            } else {
+                debug!(
+                    "Filesystem reconcile complete: checked={}, all present",
+                    self.total_checked
+                );
+            }
+            return MaintenanceResult::Done;
+        }
+
+        for row in &rows {
+            if cancel.is_cancelled() {
+                return MaintenanceResult::Yielded;
+            }
+
+            self.total_checked += 1;
+            let file_path: &str = row.try_get("file_path").unwrap_or("");
+            if file_path.is_empty() {
+                continue;
+            }
+
+            if std::path::Path::new(file_path).exists() {
+                continue;
+            }
+
+            // File is missing from disk
+            self.files_missing += 1;
+            let tenant_id: String = row.try_get("tenant_id").unwrap_or_default();
+            let branch: String = row.try_get("branch").unwrap_or_default();
+            let collection: String = row.try_get("collection").unwrap_or_default();
+
+            let payload = serde_json::json!({ "file_path": file_path });
+            if let Err(e) = ctx
+                .queue_manager
+                .enqueue_unified(
+                    ItemType::File,
+                    QueueOperation::Delete,
+                    &tenant_id,
+                    &collection,
+                    &payload.to_string(),
+                    Some(&branch),
+                    None,
+                )
+                .await
+            {
+                warn!(
+                    "Failed to enqueue delete for missing file {}: {}",
+                    file_path, e
+                );
+            } else {
+                info!("Enqueued delete for missing file: {}", file_path);
+            }
+        }
+
+        self.offset += self.batch_size;
+        MaintenanceResult::Continue
+    }
+}

--- a/src/rust/daemon/core/src/idle/tasks/filesystem_reconcile.rs
+++ b/src/rust/daemon/core/src/idle/tasks/filesystem_reconcile.rs
@@ -73,8 +73,15 @@ impl MaintenanceTask for FilesystemReconcileTask {
         .bind(self.batch_size)
         .bind(self.offset)
         .fetch_all(ctx.pool)
-        .await
-        .unwrap_or_default();
+        .await;
+
+        let rows = match rows {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Filesystem reconcile query failed: {} — will retry", e);
+                return MaintenanceResult::Yielded;
+            }
+        };
 
         if rows.is_empty() {
             if self.files_missing > 0 {

--- a/src/rust/daemon/core/src/idle/tasks/mod.rs
+++ b/src/rust/daemon/core/src/idle/tasks/mod.rs
@@ -1,0 +1,7 @@
+//! Concrete maintenance task implementations.
+
+mod filesystem_reconcile;
+mod orphan_cleanup;
+
+pub use filesystem_reconcile::FilesystemReconcileTask;
+pub use orphan_cleanup::OrphanCleanupTask;

--- a/src/rust/daemon/core/src/idle/tasks/orphan_cleanup.rs
+++ b/src/rust/daemon/core/src/idle/tasks/orphan_cleanup.rs
@@ -1,0 +1,170 @@
+//! Qdrant orphan cleanup — detect and remove points that exist in SQLite
+//! `qdrant_chunks` but not in Qdrant (or vice versa).
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use sqlx::Row;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::idle::task::{MaintenanceContext, MaintenanceResult, MaintenanceTask};
+use crate::idle::IdleState;
+
+/// Reconciles `qdrant_chunks` (SQLite) against actual Qdrant point storage.
+///
+/// Runs only in `FullIdle` (needs both Qdrant and SQLite). Processes files
+/// in batches, checking each file's tracked point IDs against Qdrant.
+/// Orphaned SQLite entries (points not in Qdrant) are deleted from
+/// `qdrant_chunks` so the tracking state is accurate.
+pub struct OrphanCleanupTask {
+    batch_size: i64,
+    offset: i64,
+    total_checked: u64,
+    orphans_cleaned: u64,
+}
+
+impl OrphanCleanupTask {
+    pub fn new() -> Self {
+        Self {
+            batch_size: 50,
+            offset: 0,
+            total_checked: 0,
+            orphans_cleaned: 0,
+        }
+    }
+}
+
+#[async_trait]
+impl MaintenanceTask for OrphanCleanupTask {
+    fn name(&self) -> &str {
+        "orphan_cleanup"
+    }
+
+    fn required_idle_states(&self) -> &[IdleState] {
+        &[IdleState::FullIdle]
+    }
+
+    fn idle_delay_secs(&self) -> u64 {
+        120 // 2 minutes of idle
+    }
+
+    fn cooldown_secs(&self) -> u64 {
+        3600 // once per hour
+    }
+
+    fn reset(&mut self) {
+        self.offset = 0;
+        self.total_checked = 0;
+        self.orphans_cleaned = 0;
+    }
+
+    async fn run_batch(
+        &mut self,
+        ctx: &MaintenanceContext<'_>,
+        cancel: &CancellationToken,
+    ) -> MaintenanceResult {
+        // Get a batch of files that have qdrant_chunks entries
+        let rows = sqlx::query(
+            "SELECT DISTINCT tf.file_id, tf.file_path, tf.collection
+             FROM tracked_files tf
+             JOIN qdrant_chunks qc ON tf.file_id = qc.file_id
+             ORDER BY tf.file_id
+             LIMIT ?1 OFFSET ?2",
+        )
+        .bind(self.batch_size)
+        .bind(self.offset)
+        .fetch_all(ctx.pool)
+        .await
+        .unwrap_or_default();
+
+        if rows.is_empty() {
+            if self.orphans_cleaned > 0 {
+                info!(
+                    "Orphan cleanup complete: files_checked={}, orphans_cleaned={}",
+                    self.total_checked, self.orphans_cleaned
+                );
+            } else {
+                debug!(
+                    "Orphan cleanup complete: checked={}, no orphans",
+                    self.total_checked
+                );
+            }
+            return MaintenanceResult::Done;
+        }
+
+        for row in &rows {
+            if cancel.is_cancelled() {
+                return MaintenanceResult::Yielded;
+            }
+
+            let file_id: i64 = row.try_get("file_id").unwrap_or(0);
+            let file_path: String = row.try_get("file_path").unwrap_or_default();
+            let collection: String = row.try_get("collection").unwrap_or_default();
+            self.total_checked += 1;
+
+            // Get point IDs tracked in SQLite for this file
+            let sqlite_points: Vec<String> =
+                sqlx::query_scalar("SELECT point_id FROM qdrant_chunks WHERE file_id = ?1")
+                    .bind(file_id)
+                    .fetch_all(ctx.pool)
+                    .await
+                    .unwrap_or_default();
+
+            if sqlite_points.is_empty() {
+                continue;
+            }
+
+            // Check which points actually exist in Qdrant
+            let qdrant_existing = match ctx
+                .storage_client
+                .check_points_exist(&collection, &sqlite_points)
+                .await
+            {
+                Ok(existing) => existing,
+                Err(e) => {
+                    warn!(
+                        "Orphan check failed for {} ({}): {}",
+                        file_path, collection, e
+                    );
+                    continue;
+                }
+            };
+
+            // Find orphans: in SQLite but not in Qdrant
+            let sqlite_set: HashSet<&str> = sqlite_points.iter().map(String::as_str).collect();
+            let orphans: Vec<&str> = sqlite_set
+                .iter()
+                .filter(|id| !qdrant_existing.contains(**id))
+                .copied()
+                .collect();
+
+            if orphans.is_empty() {
+                continue;
+            }
+
+            debug!(
+                "File {} has {} orphaned qdrant_chunks entries",
+                file_path,
+                orphans.len()
+            );
+
+            for point_id in &orphans {
+                if let Err(e) =
+                    sqlx::query("DELETE FROM qdrant_chunks WHERE point_id = ?1 AND file_id = ?2")
+                        .bind(point_id)
+                        .bind(file_id)
+                        .execute(ctx.pool)
+                        .await
+                {
+                    warn!("Failed to delete orphan chunk {}: {}", point_id, e);
+                } else {
+                    self.orphans_cleaned += 1;
+                }
+            }
+        }
+
+        self.offset += self.batch_size;
+        MaintenanceResult::Continue
+    }
+}

--- a/src/rust/daemon/core/src/idle/tasks/orphan_cleanup.rs
+++ b/src/rust/daemon/core/src/idle/tasks/orphan_cleanup.rs
@@ -75,8 +75,15 @@ impl MaintenanceTask for OrphanCleanupTask {
         .bind(self.batch_size)
         .bind(self.offset)
         .fetch_all(ctx.pool)
-        .await
-        .unwrap_or_default();
+        .await;
+
+        let rows = match rows {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Orphan cleanup query failed: {} — will retry", e);
+                return MaintenanceResult::Yielded;
+            }
+        };
 
         if rows.is_empty() {
             if self.orphans_cleaned > 0 {
@@ -98,9 +105,17 @@ impl MaintenanceTask for OrphanCleanupTask {
                 return MaintenanceResult::Yielded;
             }
 
-            let file_id: i64 = row.try_get("file_id").unwrap_or(0);
-            let file_path: String = row.try_get("file_path").unwrap_or_default();
-            let collection: String = row.try_get("collection").unwrap_or_default();
+            let (file_id, file_path, collection) = match (
+                row.try_get::<i64, _>("file_id"),
+                row.try_get::<String, _>("file_path"),
+                row.try_get::<String, _>("collection"),
+            ) {
+                (Ok(id), Ok(path), Ok(col)) => (id, path, col),
+                _ => {
+                    warn!("Orphan cleanup: skipping row with missing fields");
+                    continue;
+                }
+            };
             self.total_checked += 1;
 
             // Get point IDs tracked in SQLite for this file

--- a/src/rust/daemon/core/src/lib.rs
+++ b/src/rust/daemon/core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod fts_batch_processor;
 pub mod git;
 pub mod graph;
 pub mod grouping;
+pub mod idle;
 pub mod idle_history;
 pub mod image_extraction;
 pub mod image_ingestion;

--- a/src/rust/daemon/core/src/queue_operations/mod.rs
+++ b/src/rust/daemon/core/src/queue_operations/mod.rs
@@ -9,6 +9,7 @@ mod destination;
 mod enqueue;
 mod legacy;
 mod query;
+mod triage;
 mod update;
 mod validation;
 

--- a/src/rust/daemon/core/src/queue_operations/tests/failure_retry_tests.rs
+++ b/src/rust/daemon/core/src/queue_operations/tests/failure_retry_tests.rs
@@ -1,6 +1,7 @@
 //! Failure handling, retry logic, backoff, and stale lease recovery tests.
 
 use super::*;
+use serde_json;
 
 #[tokio::test]
 async fn test_unified_queue_mark_failed_retry() {
@@ -306,8 +307,12 @@ async fn test_resurrect_failed_transient_resets_items() {
         .unwrap();
 
     // Run resurrection — only transient item should be reset
-    let count = manager.resurrect_failed_transient().await.unwrap();
-    assert_eq!(count, 1, "only the transient item should be resurrected");
+    let (resurrected, exhausted) = manager.resurrect_failed_transient(5).await.unwrap();
+    assert_eq!(
+        resurrected, 1,
+        "only the transient item should be resurrected"
+    );
+    assert_eq!(exhausted, 0, "no items should be exhausted yet");
 
     let transient_row =
         sqlx::query("SELECT status, retry_count FROM unified_queue WHERE queue_id=?1")
@@ -365,12 +370,135 @@ async fn test_resurrect_failed_transient_infrastructure() {
         .await
         .unwrap();
 
-    let count = manager.resurrect_failed_transient().await.unwrap();
+    let (resurrected, _exhausted) = manager.resurrect_failed_transient(5).await.unwrap();
     assert_eq!(
-        count, 1,
+        resurrected, 1,
         "transient_infrastructure item should be resurrected"
     );
 
+    let row = sqlx::query("SELECT status FROM unified_queue WHERE queue_id=?1")
+        .bind(&id)
+        .fetch_one(manager.pool())
+        .await
+        .unwrap();
+    let status: String = row.try_get("status").unwrap();
+    assert_eq!(status, "pending");
+}
+
+#[tokio::test]
+async fn test_resurrect_exhaustion_after_max_resurrections() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir.path().join("test_resurrect_exhaust.db");
+
+    let config = QueueConnectionConfig::with_database_path(&db_path);
+    let pool = config.create_pool().await.unwrap();
+
+    apply_sql_script(&pool, include_str!("../../schema/watch_folders_schema.sql"))
+        .await
+        .unwrap();
+
+    let manager = QueueManager::new(pool);
+    manager.init_unified_queue().await.unwrap();
+
+    let (id, _) = manager
+        .enqueue_unified(
+            ItemType::File,
+            UnifiedOp::Add,
+            "tenant-z",
+            "projects",
+            r#"{"file_path":"/z/file.rs"}"#,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Set as failed with transient error and resurrection_count already at limit
+    sqlx::query(
+        "UPDATE unified_queue SET status='failed', error_message=?1, metadata=?2 WHERE queue_id=?3",
+    )
+    .bind("[transient_infrastructure] Qdrant timeout")
+    .bind(r#"{"resurrection_count":3}"#)
+    .bind(&id)
+    .execute(manager.pool())
+    .await
+    .unwrap();
+
+    // max_resurrections=3 — item at count 3 should be exhausted
+    let (resurrected, exhausted) = manager.resurrect_failed_transient(3).await.unwrap();
+    assert_eq!(resurrected, 0);
+    assert_eq!(exhausted, 1);
+
+    // Verify error message was updated to permanent_exhausted
+    let row = sqlx::query("SELECT status, error_message FROM unified_queue WHERE queue_id=?1")
+        .bind(&id)
+        .fetch_one(manager.pool())
+        .await
+        .unwrap();
+    let status: String = row.try_get("status").unwrap();
+    let error_msg: String = row.try_get("error_message").unwrap();
+    assert_eq!(status, "failed", "exhausted items stay in failed state");
+    assert!(
+        error_msg.starts_with("[permanent_exhausted]"),
+        "error should be prefixed with [permanent_exhausted], got: {}",
+        error_msg
+    );
+}
+
+#[tokio::test]
+async fn test_resurrect_increments_resurrection_count() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir.path().join("test_resurrect_count.db");
+
+    let config = QueueConnectionConfig::with_database_path(&db_path);
+    let pool = config.create_pool().await.unwrap();
+
+    apply_sql_script(&pool, include_str!("../../schema/watch_folders_schema.sql"))
+        .await
+        .unwrap();
+
+    let manager = QueueManager::new(pool);
+    manager.init_unified_queue().await.unwrap();
+
+    let (id, _) = manager
+        .enqueue_unified(
+            ItemType::File,
+            UnifiedOp::Add,
+            "tenant-w",
+            "projects",
+            r#"{"file_path":"/w/file.rs"}"#,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Set as failed transient with no prior resurrections
+    sqlx::query("UPDATE unified_queue SET status='failed', error_message=?1 WHERE queue_id=?2")
+        .bind("[transient_infrastructure] Qdrant timeout")
+        .bind(&id)
+        .execute(manager.pool())
+        .await
+        .unwrap();
+
+    // First resurrection
+    let (resurrected, _) = manager.resurrect_failed_transient(5).await.unwrap();
+    assert_eq!(resurrected, 1);
+
+    // Check resurrection_count is now 1
+    let row = sqlx::query("SELECT metadata FROM unified_queue WHERE queue_id=?1")
+        .bind(&id)
+        .fetch_one(manager.pool())
+        .await
+        .unwrap();
+    let metadata_str: String = row.try_get("metadata").unwrap();
+    let metadata: serde_json::Value = serde_json::from_str(&metadata_str).unwrap();
+    assert_eq!(
+        metadata["resurrection_count"], 1,
+        "resurrection_count should be 1 after first resurrection"
+    );
+
+    // Verify item is pending
     let row = sqlx::query("SELECT status FROM unified_queue WHERE queue_id=?1")
         .bind(&id)
         .fetch_one(manager.pool())

--- a/src/rust/daemon/core/src/queue_operations/triage.rs
+++ b/src/rust/daemon/core/src/queue_operations/triage.rs
@@ -1,0 +1,180 @@
+//! Failed item triage — periodically examines failed queue items and applies
+//! intelligent recovery: drop unsalvageable items, skip items awaiting
+//! Qdrant recovery, and report statistics.
+
+use sqlx::Row;
+use tracing::{debug, info, warn};
+
+use super::{QueueManager, QueueResult};
+
+/// Statistics from a triage pass.
+#[derive(Debug, Default)]
+pub struct TriageStats {
+    /// Items examined
+    pub examined: u64,
+    /// Items dropped (delete ops with no tracked points, stale files, etc.)
+    pub dropped: u64,
+    /// Items left in place (awaiting recovery or not actionable)
+    pub skipped: u64,
+}
+
+impl QueueManager {
+    /// Examine failed items and drop those that are not salvageable.
+    ///
+    /// Called periodically (default: every 5 minutes) from the processing loop.
+    ///
+    /// Triage categories:
+    /// - **Delete with no tracked points**: The delete is effectively done — drop it.
+    /// - **Delete for never-tracked file**: No record in tracked_files — drop it.
+    /// - **Add/update for missing file**: File no longer exists on disk — drop it.
+    /// - **Permanent exhausted**: Already handled by resurrection — skip.
+    /// - **Awaiting recovery**: Qdrant circuit open — skip.
+    pub async fn triage_failed_items(&self) -> QueueResult<TriageStats> {
+        let rows = sqlx::query(
+            r#"SELECT queue_id, item_type, op, file_path, tenant_id, error_message
+               FROM unified_queue
+               WHERE status = 'failed'
+               LIMIT 100"#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(TriageStats::default());
+        }
+
+        let mut stats = TriageStats {
+            examined: rows.len() as u64,
+            ..Default::default()
+        };
+
+        for row in &rows {
+            let queue_id: &str = row.try_get("queue_id")?;
+            let item_type: &str = row.try_get("item_type").unwrap_or(&"");
+            let op: &str = row.try_get("op").unwrap_or(&"");
+            let file_path: Option<&str> = row.try_get("file_path").ok();
+            let error_message: &str = row.try_get("error_message").unwrap_or(&"");
+
+            // Skip items already marked as permanently exhausted
+            if error_message.starts_with("[permanent_exhausted]")
+                || error_message.starts_with("[permanent_data]")
+            {
+                stats.skipped += 1;
+                continue;
+            }
+
+            // Only triage file items — other types need manual attention
+            if item_type != "file" {
+                stats.skipped += 1;
+                continue;
+            }
+
+            let should_drop = match op {
+                "delete" => self.should_drop_failed_delete(file_path).await,
+                "add" | "update" => self.should_drop_failed_add_update(file_path).await,
+                _ => false,
+            };
+
+            if should_drop {
+                match sqlx::query("DELETE FROM unified_queue WHERE queue_id = ?1")
+                    .bind(queue_id)
+                    .execute(&self.pool)
+                    .await
+                {
+                    Ok(_) => {
+                        info!(
+                            "Triage: dropped unsalvageable {} {} item {} (file={:?})",
+                            item_type, op, queue_id, file_path
+                        );
+                        stats.dropped += 1;
+                    }
+                    Err(e) => {
+                        warn!("Triage: failed to drop item {}: {}", queue_id, e);
+                        stats.skipped += 1;
+                    }
+                }
+            } else {
+                stats.skipped += 1;
+            }
+        }
+
+        if stats.dropped > 0 {
+            info!(
+                "Triage pass: examined={}, dropped={}, skipped={}",
+                stats.examined, stats.dropped, stats.skipped
+            );
+        } else {
+            debug!("Triage pass: examined={}, nothing to drop", stats.examined);
+        }
+
+        Ok(stats)
+    }
+
+    /// Check if a failed delete item should be dropped.
+    ///
+    /// A delete is droppable when the file has no tracked points in the database
+    /// (meaning the delete is effectively already complete) or was never tracked.
+    async fn should_drop_failed_delete(&self, file_path: Option<&str>) -> bool {
+        let Some(path) = file_path else {
+            return true; // No file_path — nothing to delete
+        };
+
+        // Check if the file is tracked at all
+        let tracked = sqlx::query("SELECT file_id FROM tracked_files WHERE file_path = ?1 LIMIT 1")
+            .bind(path)
+            .fetch_optional(&self.pool)
+            .await;
+
+        match tracked {
+            Ok(Some(row)) => {
+                // File is tracked — check if it has any Qdrant chunks
+                let file_id: i64 = row.try_get("file_id").unwrap_or(0);
+                let chunk_count =
+                    sqlx::query("SELECT COUNT(*) as cnt FROM qdrant_chunks WHERE file_id = ?1")
+                        .bind(file_id)
+                        .fetch_optional(&self.pool)
+                        .await
+                        .ok()
+                        .flatten()
+                        .and_then(|r| r.try_get::<i64, _>("cnt").ok())
+                        .unwrap_or(0);
+
+                if chunk_count == 0 {
+                    debug!(
+                        "Triage: delete for {} has no qdrant_chunks — droppable",
+                        path
+                    );
+                    return true;
+                }
+                false // Has chunks — needs Qdrant to process
+            }
+            Ok(None) => {
+                debug!(
+                    "Triage: delete for {} not in tracked_files — droppable",
+                    path
+                );
+                true // Never tracked
+            }
+            Err(_) => false, // DB error — don't drop
+        }
+    }
+
+    /// Check if a failed add/update item should be dropped.
+    ///
+    /// An add/update is droppable when the file no longer exists on disk —
+    /// the watcher will re-enqueue it as a delete if needed.
+    async fn should_drop_failed_add_update(&self, file_path: Option<&str>) -> bool {
+        let Some(path) = file_path else {
+            return false; // No file path — can't check
+        };
+
+        if !std::path::Path::new(path).exists() {
+            debug!(
+                "Triage: add/update for {} — file no longer exists, droppable",
+                path
+            );
+            return true;
+        }
+        false
+    }
+}

--- a/src/rust/daemon/core/src/queue_operations/triage.rs
+++ b/src/rust/daemon/core/src/queue_operations/triage.rs
@@ -50,10 +50,10 @@ impl QueueManager {
 
         for row in &rows {
             let queue_id: &str = row.try_get("queue_id")?;
-            let item_type: &str = row.try_get("item_type").unwrap_or(&"");
-            let op: &str = row.try_get("op").unwrap_or(&"");
+            let item_type: &str = row.try_get("item_type")?;
+            let op: &str = row.try_get("op")?;
             let file_path: Option<&str> = row.try_get("file_path").ok();
-            let error_message: &str = row.try_get("error_message").unwrap_or(&"");
+            let error_message: &str = row.try_get("error_message")?;
 
             // Skip items already marked as permanently exhausted
             if error_message.starts_with("[permanent_exhausted]")
@@ -128,16 +128,32 @@ impl QueueManager {
         match tracked {
             Ok(Some(row)) => {
                 // File is tracked — check if it has any Qdrant chunks
-                let file_id: i64 = row.try_get("file_id").unwrap_or(0);
-                let chunk_count =
-                    sqlx::query("SELECT COUNT(*) as cnt FROM qdrant_chunks WHERE file_id = ?1")
-                        .bind(file_id)
-                        .fetch_optional(&self.pool)
-                        .await
-                        .ok()
-                        .flatten()
-                        .and_then(|r| r.try_get::<i64, _>("cnt").ok())
-                        .unwrap_or(0);
+                let file_id: i64 = match row.try_get("file_id") {
+                    Ok(id) => id,
+                    Err(e) => {
+                        warn!(
+                            "Triage: failed to read file_id for {}: {} — skipping",
+                            path, e
+                        );
+                        return false;
+                    }
+                };
+                let chunk_count = match sqlx::query(
+                    "SELECT COUNT(*) as cnt FROM qdrant_chunks WHERE file_id = ?1",
+                )
+                .bind(file_id)
+                .fetch_one(&self.pool)
+                .await
+                {
+                    Ok(r) => r.try_get::<i64, _>("cnt").unwrap_or(0),
+                    Err(e) => {
+                        warn!(
+                            "Triage: failed to count qdrant_chunks for file_id={}: {} — skipping",
+                            file_id, e
+                        );
+                        return false;
+                    }
+                };
 
                 if chunk_count == 0 {
                     debug!(
@@ -155,7 +171,13 @@ impl QueueManager {
                 );
                 true // Never tracked
             }
-            Err(_) => false, // DB error — don't drop
+            Err(e) => {
+                warn!(
+                    "Triage: DB error checking tracked_files for {:?}: {}",
+                    path, e
+                );
+                false
+            }
         }
     }
 

--- a/src/rust/daemon/core/src/queue_operations/update.rs
+++ b/src/rust/daemon/core/src/queue_operations/update.rs
@@ -45,39 +45,101 @@ impl QueueManager {
         Ok(())
     }
 
-    /// Reset all failed items whose error_message indicates a transient failure
-    /// back to pending so they can be retried.
+    /// Reset eligible failed transient items back to pending for retry.
     ///
     /// Called periodically from the processing loop idle path (default: every hour).
     /// Only items prefixed `[transient_` are eligible — permanent failures are left
-    /// as-is.
+    /// as-is. Items that have been resurrected `max_resurrections` times are promoted
+    /// to `[permanent_exhausted]` and stop being resurrected.
     ///
-    /// Returns the number of items resurrected.
-    pub async fn resurrect_failed_transient(&self) -> QueueResult<u64> {
-        let result = sqlx::query(
-            r#"
-            UPDATE unified_queue
-            SET status        = 'pending',
-                retry_count   = 0,
-                lease_until   = NULL,
-                worker_id     = NULL,
-                qdrant_status = NULL,
-                search_status = NULL,
-                updated_at    = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-            WHERE status = 'failed'
-              AND error_message LIKE '[transient_%'
-            "#,
+    /// Returns `(resurrected, exhausted)` counts.
+    pub async fn resurrect_failed_transient(
+        &self,
+        max_resurrections: i32,
+    ) -> QueueResult<(u64, u64)> {
+        // Fetch eligible items to check resurrection_count in metadata
+        let rows = sqlx::query(
+            r#"SELECT queue_id, metadata, error_message
+               FROM unified_queue
+               WHERE status = 'failed'
+                 AND error_message LIKE '[transient_%'"#,
         )
-        .execute(&self.pool)
+        .fetch_all(&self.pool)
         .await?;
 
-        let count = result.rows_affected();
-        if count > 0 {
-            info!("Resurrected {} failed transient item(s) for retry", count);
-        } else {
+        if rows.is_empty() {
             debug!("Resurrection pass: no transient failed items to reset");
+            return Ok((0, 0));
         }
-        Ok(count)
+
+        let mut resurrected: u64 = 0;
+        let mut exhausted: u64 = 0;
+
+        for row in &rows {
+            let queue_id: &str = row.try_get("queue_id")?;
+            let metadata_str: &str = row.try_get("metadata").unwrap_or(&"{}");
+            let error_message: &str = row.try_get("error_message").unwrap_or(&"");
+
+            let mut metadata: serde_json::Value =
+                serde_json::from_str(metadata_str).unwrap_or_else(|_| serde_json::json!({}));
+            let count = metadata
+                .get("resurrection_count")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0) as i32;
+
+            if count >= max_resurrections {
+                // Promote to permanent — stop resurrecting
+                let exhausted_msg = format!("[permanent_exhausted] {}", error_message);
+                sqlx::query(
+                    r#"UPDATE unified_queue
+                       SET error_message = ?1,
+                           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                       WHERE queue_id = ?2"#,
+                )
+                .bind(&exhausted_msg)
+                .bind(queue_id)
+                .execute(&self.pool)
+                .await?;
+                exhausted += 1;
+                warn!(
+                    "Item {} exceeded max resurrections ({}/{}), marked permanent_exhausted",
+                    queue_id, count, max_resurrections
+                );
+            } else {
+                // Resurrect with incremented count
+                metadata["resurrection_count"] = serde_json::json!(count + 1);
+                let new_metadata = serde_json::to_string(&metadata).unwrap_or_default();
+
+                sqlx::query(
+                    r#"UPDATE unified_queue
+                       SET status = 'pending', retry_count = 0,
+                           lease_until = NULL, worker_id = NULL,
+                           qdrant_status = NULL, search_status = NULL,
+                           metadata = ?1,
+                           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                       WHERE queue_id = ?2"#,
+                )
+                .bind(&new_metadata)
+                .bind(queue_id)
+                .execute(&self.pool)
+                .await?;
+                resurrected += 1;
+            }
+        }
+
+        if resurrected > 0 {
+            info!(
+                "Resurrected {} failed transient item(s) for retry",
+                resurrected
+            );
+        }
+        if exhausted > 0 {
+            warn!(
+                "Marked {} item(s) as permanently exhausted (>{} resurrections)",
+                exhausted, max_resurrections
+            );
+        }
+        Ok((resurrected, exhausted))
     }
 
     /// Delete a unified queue item after successful processing

--- a/src/rust/daemon/core/src/queue_operations/update.rs
+++ b/src/rust/daemon/core/src/queue_operations/update.rs
@@ -77,19 +77,11 @@ impl QueueManager {
 
         for row in &rows {
             let queue_id: &str = row.try_get("queue_id")?;
-            let metadata_str: &str = row.try_get("metadata").unwrap_or(&"{}");
-            let error_message: &str = row.try_get("error_message").unwrap_or(&"");
+            let metadata_str: &str = row.try_get("metadata").unwrap_or("{}");
+            let error_message: &str = row.try_get("error_message").unwrap_or("");
 
-            let mut metadata: serde_json::Value = match serde_json::from_str(metadata_str) {
-                Ok(v) => v,
-                Err(e) => {
-                    warn!(
-                        "Item {}: unparseable metadata '{}': {} — resetting to empty",
-                        queue_id, metadata_str, e
-                    );
-                    serde_json::json!({})
-                }
-            };
+            let mut metadata: serde_json::Value =
+                serde_json::from_str(metadata_str).unwrap_or_else(|_| serde_json::json!({}));
             let count = metadata
                 .get("resurrection_count")
                 .and_then(|v| v.as_i64())
@@ -116,8 +108,7 @@ impl QueueManager {
             } else {
                 // Resurrect with incremented count
                 metadata["resurrection_count"] = serde_json::json!(count + 1);
-                let new_metadata =
-                    serde_json::to_string(&metadata).unwrap_or_else(|_| "{}".to_string());
+                let new_metadata = serde_json::to_string(&metadata).unwrap_or_default();
 
                 sqlx::query(
                     r#"UPDATE unified_queue

--- a/src/rust/daemon/core/src/queue_operations/update.rs
+++ b/src/rust/daemon/core/src/queue_operations/update.rs
@@ -80,8 +80,16 @@ impl QueueManager {
             let metadata_str: &str = row.try_get("metadata").unwrap_or(&"{}");
             let error_message: &str = row.try_get("error_message").unwrap_or(&"");
 
-            let mut metadata: serde_json::Value =
-                serde_json::from_str(metadata_str).unwrap_or_else(|_| serde_json::json!({}));
+            let mut metadata: serde_json::Value = match serde_json::from_str(metadata_str) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(
+                        "Item {}: unparseable metadata '{}': {} — resetting to empty",
+                        queue_id, metadata_str, e
+                    );
+                    serde_json::json!({})
+                }
+            };
             let count = metadata
                 .get("resurrection_count")
                 .and_then(|v| v.as_i64())
@@ -108,7 +116,8 @@ impl QueueManager {
             } else {
                 // Resurrect with incremented count
                 metadata["resurrection_count"] = serde_json::json!(count + 1);
-                let new_metadata = serde_json::to_string(&metadata).unwrap_or_default();
+                let new_metadata =
+                    serde_json::to_string(&metadata).unwrap_or_else(|_| "{}".to_string());
 
                 sqlx::query(
                     r#"UPDATE unified_queue

--- a/src/rust/daemon/core/src/search_db/mod.rs
+++ b/src/rust/daemon/core/src/search_db/mod.rs
@@ -70,6 +70,12 @@ impl SearchDbManager {
             .connect_with(connect_options)
             .await?;
 
+        // Set busy_timeout to match state.db (30 seconds) — prevents immediate
+        // SQLITE_BUSY errors when FTS5 batch writes hold the write lock.
+        sqlx::query("PRAGMA busy_timeout = 30000")
+            .execute(&pool)
+            .await?;
+
         // Verify WAL mode is active
         let journal_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
             .fetch_one(&pool)
@@ -80,7 +86,7 @@ impl SearchDbManager {
                 journal_mode
             );
         } else {
-            debug!("WAL mode confirmed for search.db");
+            debug!("WAL mode confirmed for search.db (busy_timeout=30000ms)");
         }
 
         let manager = Self { pool, path };

--- a/src/rust/daemon/core/src/storage/client.rs
+++ b/src/rust/daemon/core/src/storage/client.rs
@@ -15,6 +15,7 @@ use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 use super::config::{StorageConfig, TransportMode};
+use super::qdrant_circuit_breaker::QdrantCircuitBreaker;
 use super::types::StorageError;
 
 /// Connection pool statistics
@@ -35,6 +36,8 @@ pub struct StorageClient {
     pub(crate) config: StorageConfig,
     /// Connection pool statistics
     pub(crate) stats: Arc<tokio::sync::Mutex<ConnectionStats>>,
+    /// Circuit breaker for Qdrant availability tracking
+    circuit_breaker: Arc<QdrantCircuitBreaker>,
 }
 
 impl StorageClient {
@@ -98,6 +101,7 @@ impl StorageClient {
             client,
             config,
             stats: Arc::new(tokio::sync::Mutex::new(ConnectionStats::default())),
+            circuit_breaker: Arc::new(QdrantCircuitBreaker::with_defaults()),
         }
     }
 
@@ -121,6 +125,16 @@ impl StorageClient {
         }
     }
 
+    /// Return a shared reference to the Qdrant circuit breaker.
+    pub fn circuit_breaker(&self) -> &Arc<QdrantCircuitBreaker> {
+        &self.circuit_breaker
+    }
+
+    /// Quick check: is Qdrant presumed available (circuit not open)?
+    pub fn is_qdrant_available(&self) -> bool {
+        self.circuit_breaker.is_available()
+    }
+
     /// Get connection statistics
     pub async fn get_stats(&self) -> Result<HashMap<String, u64>, StorageError> {
         let stats = self.stats.lock().await;
@@ -141,12 +155,24 @@ impl StorageClient {
         Ok(result)
     }
 
-    /// Retry operation with exponential backoff
+    /// Retry operation with exponential backoff and circuit breaker integration.
+    ///
+    /// If the circuit breaker is open, returns immediately with a
+    /// `StorageError::Connection` indicating Qdrant is unavailable.
+    /// Successful operations feed `record_success()` into the circuit
+    /// breaker; failures feed `record_failure()`.
     pub(crate) async fn retry_operation<F, Fut, T>(&self, operation: F) -> Result<T, StorageError>
     where
         F: Fn() -> Fut,
         Fut: std::future::Future<Output = Result<T, StorageError>>,
     {
+        // Circuit breaker gate: fail fast when Qdrant is presumed down
+        if !self.circuit_breaker.is_available() {
+            return Err(StorageError::Connection(
+                "Qdrant circuit breaker open — service presumed unavailable".to_string(),
+            ));
+        }
+
         let mut attempt = 0;
         let max_retries = self.config.max_retries;
         let base_delay = Duration::from_millis(self.config.retry_delay_ms);
@@ -158,6 +184,7 @@ impl StorageClient {
                         info!("Operation succeeded after {} retries", attempt);
                     }
                     self.update_stats(|stats| stats.total_requests += 1).await;
+                    self.circuit_breaker.record_success();
                     return Ok(result);
                 }
                 Err(e) => {
@@ -167,9 +194,17 @@ impl StorageClient {
                         stats.total_errors += 1;
                     })
                     .await;
+                    let just_opened = self.circuit_breaker.record_failure();
 
-                    if attempt >= max_retries {
-                        error!("Operation failed after {} attempts: {}", attempt, e);
+                    if attempt >= max_retries || just_opened {
+                        if just_opened {
+                            error!(
+                                "Qdrant circuit breaker opened after {} failures — halting retries: {}",
+                                attempt, e
+                            );
+                        } else {
+                            error!("Operation failed after {} attempts: {}", attempt, e);
+                        }
                         return Err(e);
                     }
 

--- a/src/rust/daemon/core/src/storage/mod.rs
+++ b/src/rust/daemon/core/src/storage/mod.rs
@@ -19,6 +19,7 @@ mod collections;
 pub mod config;
 pub(crate) mod convert;
 mod points;
+pub mod qdrant_circuit_breaker;
 mod scroll;
 mod search;
 pub mod types;
@@ -29,6 +30,8 @@ pub mod types;
 pub use client::StorageClient;
 
 pub use config::{Http2Config, MultiTenantConfig, StorageConfig, TransportMode};
+
+pub use qdrant_circuit_breaker::QdrantCircuitBreaker;
 
 pub use types::{
     BatchStats, CollectionInfoResult, DocumentPoint, HybridSearchMode, HybridSearchParams,

--- a/src/rust/daemon/core/src/storage/points.rs
+++ b/src/rust/daemon/core/src/storage/points.rs
@@ -6,7 +6,8 @@
 use std::time::Duration;
 
 use qdrant_client::qdrant::{
-    Condition, CountPointsBuilder, DeletePointsBuilder, Filter, PointStruct, UpsertPoints,
+    Condition, CountPointsBuilder, DeletePointsBuilder, Filter, GetPointsBuilder, PointStruct,
+    UpsertPoints,
 };
 use tokio::time::sleep;
 use tracing::{debug, error, info};
@@ -583,5 +584,63 @@ impl StorageClient {
             .await?;
 
         Ok(count.result.map(|r| r.count).unwrap_or(0))
+    }
+
+    /// Check which point UUIDs exist in a collection.
+    ///
+    /// Fetches points by ID with no payload or vectors (minimal overhead).
+    /// Returns the set of IDs that actually exist in Qdrant.
+    pub async fn check_points_exist(
+        &self,
+        collection_name: &str,
+        point_ids: &[String],
+    ) -> Result<std::collections::HashSet<String>, StorageError> {
+        use qdrant_client::qdrant::PointId;
+        use std::collections::HashSet;
+
+        if point_ids.is_empty() {
+            return Ok(HashSet::new());
+        }
+
+        let ids: Vec<PointId> = point_ids
+            .iter()
+            .map(|id| PointId::from(id.as_str()))
+            .collect();
+
+        let response = self
+            .retry_operation(|| async {
+                let builder = GetPointsBuilder::new(collection_name, ids.clone())
+                    .with_payload(false)
+                    .with_vectors(false);
+                self.client
+                    .get_points(builder)
+                    .await
+                    .map_err(|e| StorageError::Point(e.to_string()))
+            })
+            .await?;
+
+        let existing: HashSet<String> = response
+            .result
+            .into_iter()
+            .filter_map(|p| {
+                p.id.and_then(|pid| {
+                    use qdrant_client::qdrant::point_id::PointIdOptions;
+                    match pid.point_id_options {
+                        Some(PointIdOptions::Uuid(u)) => Some(u),
+                        Some(PointIdOptions::Num(n)) => Some(n.to_string()),
+                        None => None,
+                    }
+                })
+            })
+            .collect();
+
+        debug!(
+            "check_points_exist: {}/{} points exist in {}",
+            existing.len(),
+            point_ids.len(),
+            collection_name
+        );
+
+        Ok(existing)
     }
 }

--- a/src/rust/daemon/core/src/storage/qdrant_circuit_breaker.rs
+++ b/src/rust/daemon/core/src/storage/qdrant_circuit_breaker.rs
@@ -41,33 +41,33 @@ impl QdrantCircuitBreaker {
     /// Check if the circuit allows a request. Returns `true` if requests
     /// should proceed, `false` if the circuit is open (Qdrant presumed down).
     pub fn is_available(&self) -> bool {
-        let mut cb = self.inner.lock().unwrap();
+        let mut cb = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let (can_proceed, _reason) = cb.check();
         can_proceed
     }
 
     /// Record a successful Qdrant operation.
     pub fn record_success(&self) {
-        let mut cb = self.inner.lock().unwrap();
+        let mut cb = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         cb.record_success();
     }
 
     /// Record a failed Qdrant operation. Returns `true` if the circuit
     /// just transitioned to open.
     pub fn record_failure(&self) -> bool {
-        let mut cb = self.inner.lock().unwrap();
+        let mut cb = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         cb.record_failure()
     }
 
     /// Return the current state as a string ("closed", "open", "half-open").
     pub fn state_str(&self) -> &'static str {
-        let cb = self.inner.lock().unwrap();
+        let cb = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         cb.state_str()
     }
 
     /// Return `true` if the circuit is closed (normal operation).
     pub fn is_closed(&self) -> bool {
-        let cb = self.inner.lock().unwrap();
+        let cb = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         cb.is_closed()
     }
 

--- a/src/rust/daemon/core/src/storage/qdrant_circuit_breaker.rs
+++ b/src/rust/daemon/core/src/storage/qdrant_circuit_breaker.rs
@@ -1,0 +1,133 @@
+//! Thread-safe Qdrant circuit breaker for the StorageClient.
+//!
+//! Wraps the existing `CircuitBreaker` from `queue_error_handler` in an
+//! `Arc<Mutex<>>` so it can be shared across async tasks and the queue
+//! processor's health-check loop.
+
+use std::sync::Mutex;
+use tracing::{debug, info};
+
+use crate::queue_error_handler::{CircuitBreaker, CircuitBreakerConfig};
+
+/// Thread-safe Qdrant availability tracker.
+///
+/// Intended to be stored as `Arc<QdrantCircuitBreaker>` inside `StorageClient`
+/// and shared with the queue processor and health-check loop.
+pub struct QdrantCircuitBreaker {
+    inner: Mutex<CircuitBreaker>,
+}
+
+impl QdrantCircuitBreaker {
+    /// Create a new circuit breaker with the given configuration.
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            inner: Mutex::new(CircuitBreaker::new("qdrant", config)),
+        }
+    }
+
+    /// Create with defaults tuned for Qdrant:
+    /// - Open after 5 failures within 60 seconds
+    /// - Stay open for 30 seconds
+    /// - Close after 2 successes in half-open
+    pub fn with_defaults() -> Self {
+        Self::new(CircuitBreakerConfig {
+            failure_threshold: 5,
+            failure_window: 60,
+            recovery_timeout: 30,
+            success_threshold: 2,
+        })
+    }
+
+    /// Check if the circuit allows a request. Returns `true` if requests
+    /// should proceed, `false` if the circuit is open (Qdrant presumed down).
+    pub fn is_available(&self) -> bool {
+        let mut cb = self.inner.lock().unwrap();
+        let (can_proceed, _reason) = cb.check();
+        can_proceed
+    }
+
+    /// Record a successful Qdrant operation.
+    pub fn record_success(&self) {
+        let mut cb = self.inner.lock().unwrap();
+        cb.record_success();
+    }
+
+    /// Record a failed Qdrant operation. Returns `true` if the circuit
+    /// just transitioned to open.
+    pub fn record_failure(&self) -> bool {
+        let mut cb = self.inner.lock().unwrap();
+        cb.record_failure()
+    }
+
+    /// Return the current state as a string ("closed", "open", "half-open").
+    pub fn state_str(&self) -> &'static str {
+        let cb = self.inner.lock().unwrap();
+        cb.state_str()
+    }
+
+    /// Return `true` if the circuit is closed (normal operation).
+    pub fn is_closed(&self) -> bool {
+        let cb = self.inner.lock().unwrap();
+        cb.is_closed()
+    }
+
+    /// Log the current state at debug level.
+    pub fn log_state(&self) {
+        let state = self.state_str();
+        if state != "closed" {
+            info!("Qdrant circuit breaker state: {}", state);
+        } else {
+            debug!("Qdrant circuit breaker state: closed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_starts_closed() {
+        let cb = QdrantCircuitBreaker::with_defaults();
+        assert!(cb.is_available());
+        assert!(cb.is_closed());
+        assert_eq!(cb.state_str(), "closed");
+    }
+
+    #[test]
+    fn test_opens_after_threshold_failures() {
+        let cb = QdrantCircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 3,
+            failure_window: 60,
+            recovery_timeout: 30,
+            success_threshold: 2,
+        });
+
+        // 2 failures: still closed
+        cb.record_failure();
+        cb.record_failure();
+        assert!(cb.is_available());
+
+        // 3rd failure: opens
+        let just_opened = cb.record_failure();
+        assert!(just_opened);
+        assert!(!cb.is_available());
+        assert_eq!(cb.state_str(), "open");
+    }
+
+    #[test]
+    fn test_success_resets_in_closed_state() {
+        let cb = QdrantCircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 3,
+            failure_window: 60,
+            recovery_timeout: 30,
+            success_threshold: 2,
+        });
+
+        cb.record_failure();
+        cb.record_failure();
+        cb.record_success(); // should not change state (still closed)
+        assert!(cb.is_available());
+        assert!(cb.is_closed());
+    }
+}

--- a/src/rust/daemon/core/src/strategies/processing/file/delete.rs
+++ b/src/rust/daemon/core/src/strategies/processing/file/delete.rs
@@ -81,11 +81,23 @@ pub(super) async fn process_file_delete(
                 .unwrap_or_default();
 
             if !point_ids.is_empty() {
-                // Delete from Qdrant first (irreversible), scoped to tenant
-                ctx.storage_client
+                // Delete from Qdrant (best-effort for deletes — orphaned points are
+                // acceptable; blocking the queue is not).
+                match ctx
+                    .storage_client
                     .delete_points_by_filter(&item.collection, abs_file_path, &item.tenant_id)
                     .await
-                    .map_err(|e| UnifiedProcessorError::Storage(e.to_string()))?;
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        warn!(
+                            "Qdrant delete failed for {} ({} tracked points): {} — proceeding with SQLite cleanup",
+                            relative_path,
+                            point_ids.len(),
+                            e
+                        );
+                    }
+                }
             }
         }
         timings.push(PhaseTiming {
@@ -179,26 +191,37 @@ pub(super) async fn process_file_delete(
         return Ok(());
     }
 
-    // Fallback: file not in tracked_files, attempt Qdrant filter delete (tenant-scoped)
-    warn!(
-        "File not in tracked_files, falling back to Qdrant filter delete: {}",
+    // Fallback: file not in tracked_files, attempt Qdrant filter delete (tenant-scoped).
+    // Best-effort: if Qdrant is down the file was likely never indexed (or points
+    // are already gone). Orphaned points are acceptable; blocking the queue is not.
+    debug!(
+        "File not in tracked_files, attempting Qdrant filter delete: {}",
         abs_file_path
     );
     let t0 = Instant::now();
-    ctx.storage_client
+    match ctx
+        .storage_client
         .delete_points_by_filter(&item.collection, abs_file_path, &item.tenant_id)
         .await
-        .map_err(|e| UnifiedProcessorError::Storage(e.to_string()))?;
+    {
+        Ok(_) => {
+            info!(
+                "Deleted points for file (fallback) in {}ms: {}",
+                delete_start.elapsed().as_millis(),
+                abs_file_path
+            );
+        }
+        Err(e) => {
+            warn!(
+                "Qdrant fallback delete failed for {}: {} — treating as success (points may not exist)",
+                abs_file_path, e
+            );
+        }
+    }
     timings.push(PhaseTiming {
         phase: "qdrant_delete",
         duration_ms: t0.elapsed().as_millis() as u64,
     });
-
-    info!(
-        "Deleted points for file (fallback) in {}ms: {}",
-        delete_start.elapsed().as_millis(),
-        abs_file_path
-    );
 
     record_delete_timings(ctx, item, pool, detected_language, &timings).await;
     Ok(())

--- a/src/rust/daemon/core/src/strategies/processing/file/fts5_index.rs
+++ b/src/rust/daemon/core/src/strategies/processing/file/fts5_index.rs
@@ -18,7 +18,8 @@ use wqm_common::hashing::compute_content_hash;
 ///
 /// Reads the file from disk, compares content hash against indexed_content cache.
 /// If changed (or new), computes line diff and applies to code_lines + FTS5.
-/// Failures are logged but non-fatal -- they don't block Qdrant ingestion.
+/// Returns `Ok(true)` if updated, `Ok(false)` if skipped (unchanged/binary),
+/// `Err` if the FTS5 write failed.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn update_fts5_for_file(
     search_db: &Arc<SearchDbManager>,
@@ -30,7 +31,7 @@ pub(super) async fn update_fts5_for_file(
     base_point: Option<&str>,
     relative_path: Option<&str>,
     file_hash: Option<&str>,
-) {
+) -> Result<bool, String> {
     let fts_start = std::time::Instant::now();
 
     // Read file content from disk
@@ -41,7 +42,7 @@ pub(super) async fn update_fts5_for_file(
                 "FTS5: cannot read file for indexing (may be binary): {}: {}",
                 file_path, e
             );
-            return;
+            return Ok(false);
         }
     };
 
@@ -55,7 +56,7 @@ pub(super) async fn update_fts5_for_file(
                     "FTS5: content unchanged (hash match), skipping: {}",
                     file_path
                 );
-                return;
+                return Ok(false);
             }
             // Content changed -- use cached content as diff base
             String::from_utf8(cached_bytes).unwrap_or_default()
@@ -134,12 +135,11 @@ pub(super) async fn update_fts5_for_file(
                     file_id, e
                 );
             }
+            Ok(true)
         }
         Err(e) => {
-            warn!(
-                "FTS5: failed to update code_lines for {}: {} (non-fatal)",
-                file_path, e
-            );
+            warn!("FTS5: failed to update code_lines for {}: {}", file_path, e);
+            Err(format!("FTS5 indexing failed for {}: {}", file_path, e))
         }
     }
 }

--- a/src/rust/daemon/core/src/strategies/processing/file/ingest.rs
+++ b/src/rust/daemon/core/src/strategies/processing/file/ingest.rs
@@ -96,7 +96,7 @@ async fn handle_retry_skip(
                 .queue_manager
                 .update_destination_status(&item.queue_id, "search", DestinationStatus::InProgress)
                 .await;
-            fts5_index::update_fts5_for_file(
+            let fts_status = match fts5_index::update_fts5_for_file(
                 sdb,
                 pool,
                 existing.file_id,
@@ -107,10 +107,20 @@ async fn handle_retry_skip(
                 Some(relative_path),
                 Some(existing.file_hash.as_str()),
             )
-            .await;
+            .await
+            {
+                Ok(_) => DestinationStatus::Done,
+                Err(e) => {
+                    warn!(
+                        "FTS5 retry failed for {} — search_status set to Failed: {}",
+                        payload.file_path, e
+                    );
+                    DestinationStatus::Failed
+                }
+            };
             let _ = ctx
                 .queue_manager
-                .update_destination_status(&item.queue_id, "search", DestinationStatus::Done)
+                .update_destination_status(&item.queue_id, "search", fts_status)
                 .await;
         } else {
             let _ = ctx
@@ -408,8 +418,9 @@ async fn update_search_index(
         .update_destination_status(&item.queue_id, "search", DestinationStatus::InProgress)
         .await;
     let t0 = Instant::now();
+    let mut fts_ok = true;
     if let Some(sdb) = &ctx.search_db {
-        fts5_index::update_fts5_for_file(
+        match fts5_index::update_fts5_for_file(
             sdb,
             pool,
             file_id,
@@ -420,15 +431,30 @@ async fn update_search_index(
             Some(relative_path),
             Some(file_hash),
         )
-        .await;
+        .await
+        {
+            Ok(_) => {}
+            Err(e) => {
+                warn!(
+                    "FTS5 indexing failed for {} — search_status set to Failed: {}",
+                    payload.file_path, e
+                );
+                fts_ok = false;
+            }
+        }
     }
     timings.push(PhaseTiming {
         phase: "fts5",
         duration_ms: t0.elapsed().as_millis() as u64,
     });
+    let search_status = if fts_ok {
+        DestinationStatus::Done
+    } else {
+        DestinationStatus::Failed
+    };
     let _ = ctx
         .queue_manager
-        .update_destination_status(&item.queue_id, "search", DestinationStatus::Done)
+        .update_destination_status(&item.queue_id, "search", search_status)
         .await;
 }
 

--- a/src/rust/daemon/core/src/unified_queue_processor/config.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/config.rs
@@ -104,9 +104,6 @@ pub struct UnifiedProcessorConfig {
     /// Maximum number of resurrections before an item is marked as permanently exhausted.
     /// Default: 5. After this many resurrection cycles, the item stops being resurrected.
     pub max_resurrections: i32,
-    /// Qdrant health check interval in seconds. 0 to disable.
-    /// Default: 30. When health check succeeds after a failure, triggers resurrection.
-    pub health_check_interval_secs: u64,
     /// Failed item triage interval in seconds. 0 to disable.
     /// Default: 300 (5 minutes). Examines failed items for salvageable conditions.
     pub triage_interval_secs: u64,
@@ -143,7 +140,6 @@ impl Default for UnifiedProcessorConfig {
             // Failed item resurrection
             failed_resurrection_interval_secs: 3600,
             max_resurrections: 5,
-            health_check_interval_secs: 30,
             triage_interval_secs: 300,
         }
     }

--- a/src/rust/daemon/core/src/unified_queue_processor/config.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/config.rs
@@ -101,6 +101,9 @@ pub struct UnifiedProcessorConfig {
     /// How often (seconds) to scan for failed transient items and reset them to pending.
     /// Default: 3600 (1 hour). Set to 0 to disable.
     pub failed_resurrection_interval_secs: u64,
+    /// Maximum number of resurrections before an item is marked as permanently exhausted.
+    /// Default: 5. After this many resurrection cycles, the item stops being resurrected.
+    pub max_resurrections: i32,
 }
 
 impl Default for UnifiedProcessorConfig {
@@ -133,6 +136,7 @@ impl Default for UnifiedProcessorConfig {
             onnx_intra_threads: 2,
             // Failed item resurrection
             failed_resurrection_interval_secs: 3600,
+            max_resurrections: 5,
         }
     }
 }

--- a/src/rust/daemon/core/src/unified_queue_processor/config.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/config.rs
@@ -104,6 +104,12 @@ pub struct UnifiedProcessorConfig {
     /// Maximum number of resurrections before an item is marked as permanently exhausted.
     /// Default: 5. After this many resurrection cycles, the item stops being resurrected.
     pub max_resurrections: i32,
+    /// Qdrant health check interval in seconds. 0 to disable.
+    /// Default: 30. When health check succeeds after a failure, triggers resurrection.
+    pub health_check_interval_secs: u64,
+    /// Failed item triage interval in seconds. 0 to disable.
+    /// Default: 300 (5 minutes). Examines failed items for salvageable conditions.
+    pub triage_interval_secs: u64,
 }
 
 impl Default for UnifiedProcessorConfig {
@@ -137,6 +143,8 @@ impl Default for UnifiedProcessorConfig {
             // Failed item resurrection
             failed_resurrection_interval_secs: 3600,
             max_resurrections: 5,
+            health_check_interval_secs: 30,
+            triage_interval_secs: 300,
         }
     }
 }

--- a/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
@@ -188,12 +188,24 @@ impl UnifiedQueueProcessor {
                 debug!("Qdrant circuit breaker open — probing before dequeue");
                 match storage_client.test_connection().await {
                     Ok(true) => {
+                        // Record success so the circuit breaker transitions
+                        // from HalfOpen → Closed (requires success_threshold successes).
+                        storage_client.circuit_breaker().record_success();
                         info!("Qdrant recovered — resuming queue processing");
-                        // Circuit breaker transitions via is_available() → half-open check.
-                        // Trigger resurrection so recovered items get retried promptly.
-                        let _ = queue_manager
+                        match queue_manager
                             .resurrect_failed_transient(config.max_resurrections)
-                            .await;
+                            .await
+                        {
+                            Ok((resurrected, exhausted)) => {
+                                if resurrected > 0 || exhausted > 0 {
+                                    info!(
+                                        "Recovery resurrection: reset {} item(s), exhausted {} item(s)",
+                                        resurrected, exhausted
+                                    );
+                                }
+                            }
+                            Err(e) => warn!("Recovery resurrection failed: {}", e),
+                        }
                     }
                     _ => {
                         debug!("Qdrant still unavailable, sleeping 5s");

--- a/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
@@ -85,13 +85,6 @@ impl UnifiedQueueProcessor {
             .checked_sub(Duration::from_secs(uplift_config.min_interval_secs))
             .unwrap_or_else(std::time::Instant::now);
 
-        // Qdrant health check tracking
-        let health_check_interval_secs = config.health_check_interval_secs;
-        let mut last_health_check = std::time::Instant::now()
-            .checked_sub(Duration::from_secs(health_check_interval_secs))
-            .unwrap_or_else(std::time::Instant::now);
-        let mut qdrant_was_unhealthy = false;
-
         // Failed item triage tracking
         let triage_interval_secs = config.triage_interval_secs;
         let mut last_triage = std::time::Instant::now()
@@ -183,11 +176,25 @@ impl UnifiedQueueProcessor {
                 continue;
             }
 
-            // Qdrant circuit breaker: pause dequeuing when Qdrant is presumed down
+            // Qdrant circuit breaker: when open, probe once to detect recovery
+            // instead of dequeuing items that will immediately fail.
             if !storage_client.is_qdrant_available() {
-                debug!("Qdrant circuit breaker open, pausing queue processing for 5s");
-                tokio::time::sleep(Duration::from_secs(5)).await;
-                continue;
+                debug!("Qdrant circuit breaker open — probing before dequeue");
+                match storage_client.test_connection().await {
+                    Ok(true) => {
+                        info!("Qdrant recovered — resuming queue processing");
+                        // Circuit breaker transitions via is_available() → half-open check.
+                        // Trigger resurrection so recovered items get retried promptly.
+                        let _ = queue_manager
+                            .resurrect_failed_transient(config.max_resurrections)
+                            .await;
+                    }
+                    _ => {
+                        debug!("Qdrant still unavailable, sleeping 5s");
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                        continue;
+                    }
+                }
             }
 
             // Update queue depth in metrics and adaptive resource counter
@@ -336,32 +343,6 @@ impl UnifiedQueueProcessor {
                                 }
                             }
                             last_resurrection = std::time::Instant::now();
-                        }
-
-                        // Qdrant health check (feeds circuit breaker)
-                        if health_check_interval_secs > 0
-                            && last_health_check.elapsed().as_secs() >= health_check_interval_secs
-                        {
-                            match storage_client.test_connection().await {
-                                Ok(true) => {
-                                    if qdrant_was_unhealthy {
-                                        info!(
-                                            "Qdrant recovered — triggering resurrection of infrastructure failures"
-                                        );
-                                        let _ = queue_manager
-                                            .resurrect_failed_transient(config.max_resurrections)
-                                            .await;
-                                        qdrant_was_unhealthy = false;
-                                    }
-                                }
-                                _ => {
-                                    if !qdrant_was_unhealthy {
-                                        warn!("Qdrant health check failed");
-                                    }
-                                    qdrant_was_unhealthy = true;
-                                }
-                            }
-                            last_health_check = std::time::Instant::now();
                         }
 
                         // Failed item triage

--- a/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
@@ -97,10 +97,16 @@ impl UnifiedQueueProcessor {
             .checked_sub(Duration::from_secs(3600))
             .unwrap_or_else(std::time::Instant::now);
 
+        // Maintenance scheduler
+        let mut maintenance_scheduler = crate::idle::MaintenanceScheduler::new();
+        maintenance_scheduler
+            .register(Box::new(crate::idle::tasks::FilesystemReconcileTask::new()));
+        maintenance_scheduler.register(Box::new(crate::idle::tasks::OrphanCleanupTask::new()));
+
         info!(
-            "Unified processing loop started (batch_size={}, worker_id={}, fairness={}, warmup_window={}s)",
+            "Unified processing loop started (batch_size={}, worker_id={}, fairness={}, warmup_window={}s, maintenance_tasks={})",
             config.batch_size, config.worker_id, config.fairness_enabled,
-            config.warmup_window_secs
+            config.warmup_window_secs, maintenance_scheduler.task_count()
         );
 
         loop {
@@ -250,6 +256,29 @@ impl UnifiedQueueProcessor {
 
                         let idle_elapsed = idle_since.map_or(0, |t| t.elapsed().as_secs());
 
+                        // Maintenance scheduler — run one batch if eligible
+                        {
+                            let qdrant_available = storage_client.is_qdrant_available();
+                            let memory_pressure =
+                                Self::check_memory_pressure(config.max_memory_percent).await;
+                            let idle_state = crate::idle::IdleState::determine(
+                                0, // queue is empty (we're in the empty branch)
+                                qdrant_available,
+                                memory_pressure,
+                            );
+                            if idle_state.allows_maintenance() {
+                                let maint_ctx = crate::idle::MaintenanceContext {
+                                    pool: queue_manager.pool(),
+                                    storage_client: &storage_client,
+                                    search_db: search_db.as_ref(),
+                                    queue_manager: &queue_manager,
+                                };
+                                let _ = maintenance_scheduler
+                                    .tick(idle_state, idle_elapsed, &maint_ctx)
+                                    .await;
+                            }
+                        }
+
                         // Run grammar update check when idle long enough (Task 5)
                         if let Some(ref gm) = grammar_manager {
                             let gm_read = gm.read().await;
@@ -363,7 +392,8 @@ impl UnifiedQueueProcessor {
                         continue;
                     }
 
-                    // Queue has items — reset idle tracker
+                    // Queue has items — cancel maintenance and reset idle tracker
+                    maintenance_scheduler.cancel_active();
                     idle_since = None;
 
                     info!(

--- a/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
@@ -170,6 +170,13 @@ impl UnifiedQueueProcessor {
                 continue;
             }
 
+            // Qdrant circuit breaker: pause dequeuing when Qdrant is presumed down
+            if !storage_client.is_qdrant_available() {
+                debug!("Qdrant circuit breaker open, pausing queue processing for 5s");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                continue;
+            }
+
             // Update queue depth in metrics and adaptive resource counter
             if let Ok(depth) = queue_manager.get_unified_queue_depth(None, None).await {
                 let mut m = metrics.write().await;

--- a/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
@@ -85,6 +85,19 @@ impl UnifiedQueueProcessor {
             .checked_sub(Duration::from_secs(uplift_config.min_interval_secs))
             .unwrap_or_else(std::time::Instant::now);
 
+        // Qdrant health check tracking
+        let health_check_interval_secs = config.health_check_interval_secs;
+        let mut last_health_check = std::time::Instant::now()
+            .checked_sub(Duration::from_secs(health_check_interval_secs))
+            .unwrap_or_else(std::time::Instant::now);
+        let mut qdrant_was_unhealthy = false;
+
+        // Failed item triage tracking
+        let triage_interval_secs = config.triage_interval_secs;
+        let mut last_triage = std::time::Instant::now()
+            .checked_sub(Duration::from_secs(triage_interval_secs))
+            .unwrap_or_else(std::time::Instant::now);
+
         // Grammar idle-time update check tracking
         let mut idle_since: Option<std::time::Instant> = None;
         let mut last_grammar_check = std::time::Instant::now()
@@ -323,6 +336,42 @@ impl UnifiedQueueProcessor {
                                 }
                             }
                             last_resurrection = std::time::Instant::now();
+                        }
+
+                        // Qdrant health check (feeds circuit breaker)
+                        if health_check_interval_secs > 0
+                            && last_health_check.elapsed().as_secs() >= health_check_interval_secs
+                        {
+                            match storage_client.test_connection().await {
+                                Ok(true) => {
+                                    if qdrant_was_unhealthy {
+                                        info!(
+                                            "Qdrant recovered — triggering resurrection of infrastructure failures"
+                                        );
+                                        let _ = queue_manager
+                                            .resurrect_failed_transient(config.max_resurrections)
+                                            .await;
+                                        qdrant_was_unhealthy = false;
+                                    }
+                                }
+                                _ => {
+                                    if !qdrant_was_unhealthy {
+                                        warn!("Qdrant health check failed");
+                                    }
+                                    qdrant_was_unhealthy = true;
+                                }
+                            }
+                            last_health_check = std::time::Instant::now();
+                        }
+
+                        // Failed item triage
+                        if triage_interval_secs > 0
+                            && last_triage.elapsed().as_secs() >= triage_interval_secs
+                        {
+                            if let Err(e) = queue_manager.triage_failed_items().await {
+                                warn!("Triage pass failed (non-fatal): {}", e);
+                            }
+                            last_triage = std::time::Instant::now();
                         }
 
                         debug!(

--- a/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
+++ b/src/rust/daemon/core/src/unified_queue_processor/processing_loop/loop_core.rs
@@ -299,12 +299,15 @@ impl UnifiedQueueProcessor {
                         if resurrection_interval_secs > 0
                             && last_resurrection.elapsed().as_secs() >= resurrection_interval_secs
                         {
-                            match queue_manager.resurrect_failed_transient().await {
-                                Ok(count) => {
-                                    if count > 0 {
+                            match queue_manager
+                                .resurrect_failed_transient(config.max_resurrections)
+                                .await
+                            {
+                                Ok((resurrected, exhausted)) => {
+                                    if resurrected > 0 || exhausted > 0 {
                                         info!(
-                                            "Resurrection pass: reset {} failed transient item(s) to pending",
-                                            count
+                                            "Resurrection pass: reset {} item(s), exhausted {} item(s)",
+                                            resurrected, exhausted
                                         );
                                     }
                                 }


### PR DESCRIPTION
## Summary

- **Idempotent file deletes**: Qdrant errors on delete are warnings, not failures — orphaned points are acceptable, blocking the queue is not
- **Qdrant circuit breaker**: Opens after 5 failures/60s, pauses dequeuing, probes on-demand to detect recovery
- **Bounded resurrection**: Tracks `resurrection_count` in metadata; after 5 cycles items are promoted to `[permanent_exhausted]`
- **Failed item triage**: Drops unsalvageable items every 5 min (no-op deletes, missing files, never-tracked files)
- **Idle state taxonomy**: `FullIdle`, `QdrantDownIdle`, `ResourceConstrained`, `Active` — maintenance tasks self-select based on available resources
- **Maintenance scheduler**: Runs tasks during idle, yields immediately when work arrives, resumes from saved progress
- **FilesystemReconcileTask**: Detects tracked files missing from disk, enqueues deletes
- **OrphanCleanupTask**: Reconciles `qdrant_chunks` vs Qdrant, cleans orphaned SQLite entries
- **FTS5 error propagation**: `search_status` now correctly reflects FTS5 failures
- **search.db busy_timeout**: Was missing, now 30000ms matching state.db
- **CLI**: `wqm queue drop` and `wqm queue retry --all-transient`

## Test plan

- [x] All 2134 unit tests pass
- [x] Release binaries built and deployed
- [x] Daemon running healthy with maintenance scheduler active
- [x] `wqm queue drop --all-stale -y` successfully dropped 5 stale items
- [ ] Verify orphan cleanup runs during extended idle
- [ ] Verify filesystem reconcile detects missing files
- [ ] Verify circuit breaker pauses dequeuing during Qdrant outage