### PR TITLE
Salvage alkmimm PRs #134/#132 — read-path improvements (port to all-Rust)

### DIFF
--- a/src/rust/client/src/project.rs
+++ b/src/rust/client/src/project.rs
@@ -224,6 +224,12 @@ pub fn get_git_remote_url(repo_root: &Path) -> Option<String> {
 ///
 /// Returns `Some(ProjectInfo)` for any `cwd` (project root falls back to `cwd`).
 pub fn detect_project<L: ProjectLookup + ?Sized>(cwd: &Path, lookup: &L) -> Option<ProjectInfo> {
+    // Fold a Windows-host WSL UNC cwd (`\\wsl.localhost\<distro>\...`) to the
+    // POSIX path the daemon registered; a no-op for native paths (#134 salvage).
+    let cwd_str = cwd.to_string_lossy();
+    let folded = wqm_common::paths::canonicalize_host_path(&cwd_str);
+    let cwd: &Path = Path::new(&folded);
+
     let project_root = find_project_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
 
     let git_remote = get_git_remote_url(&project_root);

--- a/src/rust/client/src/search/flow_collect.rs
+++ b/src/rust/client/src/search/flow_collect.rs
@@ -15,7 +15,7 @@ use crate::qdrant::fusion::{
     apply_rrf_fusion, diversify_results, point_to_tagged, SearchType, TaggedResult,
     DEFAULT_DIVERSITY_CONFIG,
 };
-use wqm_common::constants::COLLECTION_LIBRARIES;
+use wqm_common::constants::{COLLECTION_LIBRARIES, RANKING_AID_KEYS};
 
 use super::flow::SearchQdrant;
 use super::options::SearchOptions;
@@ -264,6 +264,12 @@ pub fn tagged_to_search_result(tagged: TaggedResult) -> SearchResult {
         (meta, None)
     } else {
         let mut meta = payload.clone();
+        // Strip the daemon's internal ranking-aid keys (~1.5–2k tokens/hit) that
+        // a reading agent never consumes — salvaged from alkmimm PR #134.
+        // The graph branch already returns a narrow metadata object.
+        for key in RANKING_AID_KEYS {
+            meta.remove(*key);
+        }
         meta.insert(
             "_search_type".to_string(),
             Value::String(tagged.search_type.as_str().to_string()),
@@ -352,5 +358,49 @@ fn assign_parent_contexts(
                 results[idx].parent_context = Some(ctx.clone());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod ranking_aid_strip_tests {
+    use super::*;
+
+    fn payload_with_ranking_aids() -> HashMap<String, Value> {
+        let mut p = HashMap::new();
+        p.insert("content".to_string(), Value::String("body".to_string()));
+        p.insert(
+            "source_file".to_string(),
+            Value::String("src/main.rs".to_string()),
+        );
+        for key in RANKING_AID_KEYS {
+            p.insert((*key).to_string(), Value::String("noise".to_string()));
+        }
+        p
+    }
+
+    #[test]
+    fn default_search_strips_ranking_aid_keys() {
+        // Default (non-graph) results must drop the daemon's ranking-aid keys
+        // while keeping ordinary payload fields — alkmimm #134 salvage.
+        let tagged = TaggedResult {
+            id: "doc-1".to_string(),
+            score: 1.0,
+            collection: "projects".to_string(),
+            payload: payload_with_ranking_aids(),
+            search_type: SearchType::Hybrid,
+        };
+        let result = tagged_to_search_result(tagged);
+        let meta = &result.metadata;
+        for key in RANKING_AID_KEYS {
+            assert!(
+                !meta.contains_key(*key),
+                "ranking-aid key {key:?} must be stripped from default search metadata"
+            );
+        }
+        assert!(meta.contains_key("source_file"), "keeps ordinary fields");
+        assert!(
+            meta.contains_key("_search_type"),
+            "keeps the search-type tag"
+        );
     }
 }

--- a/src/rust/common/src/constants.rs
+++ b/src/rust/common/src/constants.rs
@@ -29,6 +29,25 @@ pub const TENANT_GLOBAL: &str = "global";
 /// 512-dimensional vectors (CLIP ViT-B-32), dense-only (no sparse)
 pub const COLLECTION_IMAGES: &str = "images";
 
+/// Payload keys the daemon injects on every chunk purely as retrieval/ranking
+/// aids — never meant for a reading agent to consume.
+///
+/// The daemon's keyword pipeline writes these in
+/// `daemon/core/src/strategies/processing/file/keyword_extract.rs` (the producer
+/// uses these very constants for the insert keys, so this list cannot drift from
+/// what is written). Each chunk carries ~1.5–2k tokens of them; returning them to
+/// an agent on every search/retrieve hit is pure token waste. The MCP read paths
+/// (default-mode search in `wqm-client` and the `retrieve` tool) strip these keys
+/// before handing results back.
+///
+/// Salvaged from alkmimm PR #134 (`5e7497759` item 2 / `common/payload-noise.ts`).
+pub const RANKING_AID_KEYS: &[&str] = &[
+    "keywords",
+    "concept_tags",
+    "structural_tags",
+    "keyword_baskets",
+];
+
 /// Default Qdrant server URL
 pub const DEFAULT_QDRANT_URL: &str = "http://localhost:6333";
 

--- a/src/rust/common/src/paths/mod.rs
+++ b/src/rust/common/src/paths/mod.rs
@@ -51,6 +51,7 @@ pub use discovery::{find_config_file, get_config_search_paths};
 pub use error::PathError;
 pub use local::LocalPath;
 pub use mount_map::{mount_section_hash, MountEntry, MountMap};
+pub use normalize::canonicalize_host_path;
 pub use relative::{RelativePath, RelativePathError};
 pub use resolve::{
     get_cache_dir, get_canonical_log_dir, get_config_dir, get_data_dir, get_database_path,

--- a/src/rust/common/src/paths/normalize.rs
+++ b/src/rust/common/src/paths/normalize.rs
@@ -95,3 +95,97 @@ pub(super) fn normalize_path(input: &str) -> Result<String, PathError> {
 
     Ok(normalized)
 }
+
+/// Fold a Windows-host WSL UNC path to the daemon's native POSIX path.
+///
+/// On a Windows host editing a repo that lives inside WSL, the client reports
+/// `cwd` as a UNC path such as `\\wsl.localhost\Ubuntu\home\user\repo` (or the
+/// legacy `\\wsl$\Ubuntu\...`). The daemon runs inside WSL and stored the
+/// project under `/home/user/repo`, so the UNC form never matches a registered
+/// project. This strips the `\\wsl(.localhost|$)\<distro>` prefix and converts
+/// the remaining backslashes to forward slashes, yielding the POSIX path the
+/// daemon knows. Any other input — already-POSIX, a native Windows path, a
+/// non-WSL UNC share, or a relative path — is returned unchanged.
+///
+/// Pure and syntactic: no filesystem access, no symlink resolution. The host
+/// token (`wsl.localhost` / `wsl$`) is matched case-insensitively, as Windows
+/// UNC hosts are. Salvaged from alkmimm PR #134 (`5e7497759` item 1).
+pub fn canonicalize_host_path(path: &str) -> String {
+    // Only `\\…` or `//…` UNC-style inputs can be WSL paths — everything else
+    // (POSIX, drive-letter Windows, relative) is returned untouched.
+    if !(path.starts_with("\\\\") || path.starts_with("//")) {
+        return path.to_string();
+    }
+
+    // Accept both `\\wsl$\…` and an already-forward-slashed `//wsl$/…`.
+    let slashed = path.replace('\\', "/");
+    let rest = slashed.trim_start_matches('/');
+    let mut segments = rest.split('/');
+
+    let host = segments.next().unwrap_or("").to_ascii_lowercase();
+    if host != "wsl.localhost" && host != "wsl$" {
+        // Some other UNC share (e.g. `\\server\share`) — leave it alone.
+        return path.to_string();
+    }
+
+    // The next segment is the distro name; everything after it is the POSIX
+    // path rooted at `/`.
+    let _distro = segments.next();
+    let tail: Vec<&str> = segments.filter(|s| !s.is_empty()).collect();
+    format!("/{}", tail.join("/"))
+}
+
+#[cfg(test)]
+mod host_path_tests {
+    use super::canonicalize_host_path;
+
+    #[test]
+    fn folds_wsl_localhost_unc() {
+        assert_eq!(
+            canonicalize_host_path(r"\\wsl.localhost\Ubuntu\home\user\repo"),
+            "/home/user/repo"
+        );
+    }
+
+    #[test]
+    fn folds_legacy_wsl_dollar_unc() {
+        assert_eq!(
+            canonicalize_host_path(r"\\wsl$\Debian\srv\code\proj"),
+            "/srv/code/proj"
+        );
+    }
+
+    #[test]
+    fn folds_forward_slashed_and_mixed_case_host() {
+        assert_eq!(
+            canonicalize_host_path("//WSL.LocalHost/Ubuntu/home/x"),
+            "/home/x"
+        );
+    }
+
+    #[test]
+    fn distro_root_folds_to_slash() {
+        assert_eq!(canonicalize_host_path(r"\\wsl.localhost\Ubuntu"), "/");
+    }
+
+    #[test]
+    fn posix_path_unchanged() {
+        assert_eq!(canonicalize_host_path("/home/user/repo"), "/home/user/repo");
+    }
+
+    #[test]
+    fn windows_drive_path_unchanged() {
+        assert_eq!(
+            canonicalize_host_path(r"C:\Users\x\repo"),
+            r"C:\Users\x\repo"
+        );
+    }
+
+    #[test]
+    fn non_wsl_unc_share_unchanged() {
+        assert_eq!(
+            canonicalize_host_path(r"\\fileserver\share\dir"),
+            r"\\fileserver\share\dir"
+        );
+    }
+}

--- a/src/rust/daemon/core/src/strategies/processing/file/keyword_extract.rs
+++ b/src/rust/daemon/core/src/strategies/processing/file/keyword_extract.rs
@@ -213,3 +213,33 @@ fn inject_extraction_results(extraction: &ExtractionResult, points: &mut [Docume
         }
     }
 }
+
+#[cfg(test)]
+mod ranking_aid_sync_tests {
+    use wqm_common::constants::RANKING_AID_KEYS;
+
+    /// Guard: the keys this module injects as ranking aids MUST equal
+    /// `RANKING_AID_KEYS`, which the MCP read paths use to strip them. If a new
+    /// `point.payload.insert("<key>", ...)` is added in `inject_extraction_results`
+    /// above (or a key renamed) without updating `RANKING_AID_KEYS`, that key
+    /// would leak to agents on every hit. Update both sides together; this test
+    /// fails until you do.
+    #[test]
+    fn injected_keys_match_ranking_aid_constant() {
+        // Mirror the keys inserted in `inject_extraction_results` above.
+        let injected = [
+            "keywords",
+            "concept_tags",
+            "structural_tags",
+            "keyword_baskets",
+        ];
+        let mut injected_sorted = injected.to_vec();
+        injected_sorted.sort_unstable();
+        let mut constant_sorted = RANKING_AID_KEYS.to_vec();
+        constant_sorted.sort_unstable();
+        assert_eq!(
+            injected_sorted, constant_sorted,
+            "ranking-aid payload keys drifted from wqm_common::RANKING_AID_KEYS"
+        );
+    }
+}

--- a/src/rust/daemon/mcp-server/src/tools/dispatch.rs
+++ b/src/rust/daemon/mcp-server/src/tools/dispatch.rs
@@ -227,7 +227,10 @@ async fn route_tool(
             apply_health_augmentation(raw, ctx.health_state)
         }
         "retrieve" => {
-            let input = RetrieveInput::from_args(args);
+            let input = match RetrieveInput::from_args(args) {
+                Ok(i) => i,
+                Err(e) => return error_text(&e),
+            };
             let session_project_id = ctx.session.project_id.as_deref();
             retrieve_tool(input, ctx.qdrant, session_project_id).await
         }

--- a/src/rust/daemon/mcp-server/src/tools/retrieve.rs
+++ b/src/rust/daemon/mcp-server/src/tools/retrieve.rs
@@ -40,9 +40,13 @@ mod retrieve_types;
 
 use wqm_common::constants::{
     COLLECTION_LIBRARIES, COLLECTION_PROJECTS, COLLECTION_RULES, COLLECTION_SCRATCHPAD,
+    RANKING_AID_KEYS,
 };
 
 /// Keys excluded from metadata — mirrors `extractMetadata` in retrieve-types.ts line 72.
+/// Vectors and the body `content` are stripped here; the ranking-aid keys
+/// (`RANKING_AID_KEYS`) are stripped additionally in `extract_metadata` so a
+/// reading agent never receives the daemon's internal retrieval scaffolding.
 const EXCLUDED_PAYLOAD_KEYS: &[&str] = &["content", "dense_vector", "sparse_vector"];
 
 // ---------------------------------------------------------------------------
@@ -71,6 +75,7 @@ fn extract_metadata(payload: &HashMap<String, Value>) -> Value {
     let map: serde_json::Map<String, Value> = payload
         .iter()
         .filter(|(k, _)| !EXCLUDED_PAYLOAD_KEYS.contains(&k.as_str()))
+        .filter(|(k, _)| !RANKING_AID_KEYS.contains(&k.as_str()))
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
     Value::Object(map)

--- a/src/rust/daemon/mcp-server/src/tools/retrieve_tests.rs
+++ b/src/rust/daemon/mcp-server/src/tools/retrieve_tests.rs
@@ -200,6 +200,40 @@ async fn by_id_metadata_excludes_content_and_vectors() {
     assert!(meta.contains_key("source_file"));
 }
 
+#[tokio::test]
+async fn by_id_metadata_excludes_ranking_aid_keys() {
+    // Ranking-aid keys (alkmimm #134 salvage) must be stripped from retrieve
+    // metadata — they are internal retrieval scaffolding, never for the agent.
+    let mut point = make_point("doc-1", "body", "proj-a");
+    for key in wqm_common::constants::RANKING_AID_KEYS {
+        point
+            .payload
+            .insert((*key).to_string(), Value::String("noise".to_string()));
+    }
+    let qdrant = StubQdrant {
+        points: vec![point],
+        ..Default::default()
+    };
+    let input = RetrieveInput {
+        document_id: Some("doc-1".to_string()),
+        collection: "projects".to_string(),
+        project_id: Some("proj-a".to_string()),
+        limit: 10,
+        ..Default::default()
+    };
+    let r = retrieve_tool(input, &qdrant, None).await;
+    let resp = parse_response(&r);
+    let meta = resp.documents[0].metadata.as_object().unwrap();
+    for key in wqm_common::constants::RANKING_AID_KEYS {
+        assert!(
+            !meta.contains_key(*key),
+            "ranking-aid key {key:?} must be stripped from retrieve metadata"
+        );
+    }
+    // A normal payload field still passes through.
+    assert!(meta.contains_key("source_file"));
+}
+
 // ---------------------------------------------------------------------------
 // by-id: ownership check (F-002)
 // ---------------------------------------------------------------------------

--- a/src/rust/daemon/mcp-server/src/tools/retrieve_tests_part2.rs
+++ b/src/rust/daemon/mcp-server/src/tools/retrieve_tests_part2.rs
@@ -101,7 +101,7 @@ async fn retrieve_is_daemon_independent() {
 fn from_args_defaults() {
     let args = serde_json::json!({});
     let map = args.as_object().unwrap();
-    let input = RetrieveInput::from_args(map);
+    let input = RetrieveInput::from_args(map).unwrap();
     assert!(input.document_id.is_none());
     assert_eq!(input.collection, "projects");
     assert_eq!(input.limit, 10);
@@ -123,7 +123,7 @@ fn from_args_all_fields() {
         "libraryName": "mylib"
     });
     let map = args.as_object().unwrap();
-    let input = RetrieveInput::from_args(map);
+    let input = RetrieveInput::from_args(map).unwrap();
     assert_eq!(input.document_id.as_deref(), Some("doc-abc"));
     assert_eq!(input.collection, "rules");
     assert_eq!(input.limit, 20);
@@ -132,6 +132,43 @@ fn from_args_all_fields() {
     assert_eq!(input.library_name.as_deref(), Some("mylib"));
     let f = input.filter.unwrap();
     assert_eq!(f.get("tag").map(|s| s.as_str()), Some("important"));
+}
+
+// ---------------------------------------------------------------------------
+// RetrieveInput::from_args — unknown-argument rejection (alkmimm #134 salvage)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_args_rejects_query_with_search_hint() {
+    // The canonical mistake: retrieve({query: "..."}). It must be rejected up
+    // front with a hint pointing at the `search` tool, not silently dropped.
+    let args = serde_json::json!({ "query": "how does fusion work" });
+    let map = args.as_object().unwrap();
+    let err = RetrieveInput::from_args(map).unwrap_err();
+    assert!(err.contains("query"), "names the offending key: {err}");
+    assert!(err.contains("`search` tool"), "nudges to search: {err}");
+}
+
+#[test]
+fn from_args_rejects_unknown_key() {
+    let args = serde_json::json!({ "collection": "rules", "limt": 5 });
+    let map = args.as_object().unwrap();
+    let err = RetrieveInput::from_args(map).unwrap_err();
+    assert!(err.contains("limt"), "names the typo'd key: {err}");
+    // A non-`query` typo gets the allowed-keys list but not the search nudge.
+    assert!(!err.contains("`search` tool"));
+}
+
+#[test]
+fn from_args_accepts_all_known_keys() {
+    // Every documented key must pass the guard (regression: the allowlist must
+    // not drift behind retrieve_schema()).
+    let args = serde_json::json!({
+        "documentId": "d", "collection": "projects", "filter": {},
+        "limit": 1, "offset": 0, "projectId": "p", "libraryName": "l"
+    });
+    let map = args.as_object().unwrap();
+    assert!(RetrieveInput::from_args(map).is_ok());
 }
 
 // ---------------------------------------------------------------------------

--- a/src/rust/daemon/mcp-server/src/tools/retrieve_types.rs
+++ b/src/rust/daemon/mcp-server/src/tools/retrieve_types.rs
@@ -85,6 +85,31 @@ impl RetrieveQdrant for QdrantReadClient {
 }
 
 // ---------------------------------------------------------------------------
+// Argument allowlist
+// ---------------------------------------------------------------------------
+
+/// The complete set of argument keys the `retrieve` tool accepts.
+///
+/// Kept in lock-step with `retrieve_schema()` in `tools/definitions.rs` (the
+/// published `inputSchema`). `cwd` is NOT included: in this server the working
+/// directory is carried on the session (`session.client_cwd`, #97), never as a
+/// per-call argument, so a `cwd` key in the args map is genuinely unknown.
+///
+/// Salvaged from alkmimm PR #134 (`8e61a37cc`): the TS arg-builder silently
+/// discarded unrecognized args, so a misdirected `retrieve({query: "..."})`
+/// degraded into an unrelated "no resolvable scope" error. Rejecting unknown
+/// args up front turns that confusing failure into an actionable one.
+pub const RETRIEVE_ARG_KEYS: &[&str] = &[
+    "documentId",
+    "collection",
+    "filter",
+    "limit",
+    "offset",
+    "projectId",
+    "libraryName",
+];
+
+// ---------------------------------------------------------------------------
 // Input struct
 // ---------------------------------------------------------------------------
 
@@ -104,8 +129,19 @@ pub struct RetrieveInput {
 impl RetrieveInput {
     /// Parse from the JSON `arguments` map of a `CallToolRequestParams`.
     ///
-    /// Mirrors the destructuring defaults in retrieve.ts lines 110-119.
-    pub fn from_args(args: &serde_json::Map<String, Value>) -> Self {
+    /// Mirrors the destructuring defaults in retrieve.ts lines 110-119, plus the
+    /// unknown-argument rejection salvaged from alkmimm PR #134 (`8e61a37cc`):
+    /// any key outside [`RETRIEVE_ARG_KEYS`] is rejected before scope resolution
+    /// or any Qdrant call, with a hint that points a stray `query` at the
+    /// `search` tool.
+    ///
+    /// # Errors
+    /// Returns `Err(message)` when the args map carries any unrecognized key.
+    pub fn from_args(args: &serde_json::Map<String, Value>) -> Result<Self, String> {
+        if let Some(err) = Self::reject_unknown_args(args) {
+            return Err(err);
+        }
+
         let document_id = args
             .get("documentId")
             .and_then(|v| v.as_str())
@@ -137,7 +173,7 @@ impl RetrieveInput {
             .and_then(|v| v.as_str())
             .map(str::to_string);
 
-        Self {
+        Ok(Self {
             document_id,
             collection,
             filter,
@@ -145,7 +181,38 @@ impl RetrieveInput {
             offset,
             project_id,
             library_name,
+        })
+    }
+
+    /// Return an error message if `args` contains any key outside
+    /// [`RETRIEVE_ARG_KEYS`], else `None`.
+    ///
+    /// Unknown keys are listed in their map order. When `query` is among them the
+    /// message also nudges the caller toward the `search` tool, since
+    /// `retrieve({query: ...})` is the canonical mistake this guard catches.
+    fn reject_unknown_args(args: &serde_json::Map<String, Value>) -> Option<String> {
+        let unknown: Vec<&str> = args
+            .keys()
+            .map(String::as_str)
+            .filter(|k| !RETRIEVE_ARG_KEYS.contains(k))
+            .collect();
+
+        if unknown.is_empty() {
+            return None;
         }
+
+        let mut message = format!(
+            "Unknown argument(s) for retrieve: {}. Allowed: {}.",
+            unknown.join(", "),
+            RETRIEVE_ARG_KEYS.join(", "),
+        );
+        if unknown.contains(&"query") {
+            message.push_str(
+                " The `retrieve` tool fetches known documents by id or filter; \
+                 use the `search` tool to run a query.",
+            );
+        }
+        Some(message)
     }
 }
 

--- a/src/rust/daemon/mcp-server/src/tools/rules/helpers.rs
+++ b/src/rust/daemon/mcp-server/src/tools/rules/helpers.rs
@@ -230,5 +230,10 @@ pub fn mirror_to_rule_item(row: &RulesMirrorEntry) -> RuleItem {
         created_at: Some(row.created_at.clone()),
         updated_at: Some(row.updated_at.clone()),
         similarity: None,
+        owner: Some(
+            row.tenant_id
+                .clone()
+                .unwrap_or_else(|| TENANT_GLOBAL.to_string()),
+        ),
     }
 }

--- a/src/rust/daemon/mcp-server/src/tools/rules/list.rs
+++ b/src/rust/daemon/mcp-server/src/tools/rules/list.rs
@@ -36,7 +36,7 @@ pub const DEFAULT_DUPLICATION_THRESHOLD: f64 = 0.7;
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Payload field constants — mirror `wqm_common::constants::field`.
-const FIELD_CONTENT: &str = "content";
+pub(super) const FIELD_CONTENT: &str = "content";
 const FIELD_PROJECT_ID: &str = "project_id";
 const FIELD_TITLE: &str = "title";
 

--- a/src/rust/daemon/mcp-server/src/tools/rules/list.rs
+++ b/src/rust/daemon/mcp-server/src/tools/rules/list.rs
@@ -120,6 +120,16 @@ fn point_to_rule_item(point: &crate::qdrant::client::QdrantRetrievedPoint) -> Ru
         .and_then(|v| v.as_str())
         .map(str::to_string);
 
+    // Owner = the rule's tenant (project id or "global"); explicit so an
+    // unresolved project-scope list cannot silently span tenants.
+    let owner = Some(
+        payload
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or(TENANT_GLOBAL)
+            .to_string(),
+    );
+
     RuleItem {
         id: point.id.clone(),
         content,
@@ -132,6 +142,7 @@ fn point_to_rule_item(point: &crate::qdrant::client::QdrantRetrievedPoint) -> Ru
         created_at,
         updated_at,
         similarity: None,
+        owner,
     }
 }
 
@@ -322,6 +333,7 @@ where
                 created_at: None,
                 updated_at: None,
                 similarity: Some(similarity),
+                owner: None, // similar-rule hits don't carry the list-only owner
             }
         })
         .collect()

--- a/src/rust/daemon/mcp-server/src/tools/rules/mutations.rs
+++ b/src/rust/daemon/mcp-server/src/tools/rules/mutations.rs
@@ -20,7 +20,7 @@ use crate::tools::envelope::{error_text, ok_text};
 use super::helpers::{
     build_add_metadata, build_update_metadata, queue_rule_op, resolve_tenant, upsert_mirror,
 };
-use super::list::find_similar_rules;
+use super::list::{build_duplicate_scope_filter, find_similar_rules, FIELD_CONTENT};
 use super::traits::{RulesDaemon, RulesQdrant};
 use super::types::{RulesInput, RulesResponse};
 
@@ -28,6 +28,72 @@ use super::types::{RulesInput, RulesResponse};
 // add_rule — mirrors `persistAddRule` in rules-mutation-helpers.ts:177-218
 //            with dup-check prepended from rules.ts:68-93
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Cap on rules scanned for an exact-content match. Rules collections hold
+/// behavioral rules (small by nature); this covers any realistic scope without
+/// paging. If a scope ever exceeds it, the worst case is a missed idempotency
+/// short-circuit (the fuzzy gate still catches the near-duplicate) — never a
+/// wrong result.
+const EXACT_SCAN_LIMIT: u32 = 1000;
+
+/// Read-side exact-content idempotency check (alkmimm PR #134, `5e7497759`).
+///
+/// If a rule with byte-identical trimmed content already exists in the same
+/// scope/tenant, return a success no-op WITHOUT enqueuing any write — a
+/// re-added identical rule is a no-op, not a new row or a refusal. Runs before
+/// the fuzzy similarity gate and regardless of `force`, since there is
+/// genuinely nothing to add. Deterministic and fail-open: any scroll error
+/// returns `None`, allowing the add to proceed.
+async fn add_exact_duplicate<Q>(
+    input: &RulesInput,
+    qdrant: &Q,
+    content: &str,
+    session_project_id: Option<&str>,
+) -> Option<CallToolResult>
+where
+    Q: RulesQdrant,
+{
+    let scope = input.scope.as_str();
+    let project_id = input
+        .project_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .or(session_project_id);
+    let filter = build_duplicate_scope_filter(scope, project_id);
+
+    let points = match qdrant.scroll_rules(filter, EXACT_SCAN_LIMIT).await {
+        Ok(p) => p,
+        Err(_) => return None, // fail-open: a scroll failure must not block adds
+    };
+
+    let target = content.trim();
+    let existing = points.into_iter().find(|pt| {
+        pt.payload
+            .get(FIELD_CONTENT)
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            == Some(target)
+    })?;
+
+    let label = existing
+        .payload
+        .get("label")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    Some(ok_text(&RulesResponse {
+        success: true,
+        action: "add".to_string(),
+        label,
+        rules: None,
+        similar_rules: None,
+        message: Some(format!(
+            "Identical rule already exists (id {}); no change made.",
+            existing.id
+        )),
+        fallback_mode: None,
+        queue_id: None,
+    }))
+}
 
 /// Run the duplicate-detection step. Returns `Some(refusal)` when ≥1 similar
 /// rule is found (the add must NOT proceed), `None` to allow the add. Mirrors
@@ -101,7 +167,14 @@ where
         }
     };
 
-    // 2. Dup-check BEFORE label/tenant checks — rules.ts:71-91 runs this at
+    // 2a. Exact-content idempotency (alkmimm #134): a byte-identical rule in the
+    //     same scope/tenant is a no-op, not a new row — checked before the fuzzy
+    //     gate and regardless of `force`, since there is nothing to add.
+    if let Some(noop) = add_exact_duplicate(&input, qdrant, content, session_project_id).await {
+        return noop;
+    }
+
+    // 2b. Dup-check BEFORE label/tenant checks — rules.ts:71-91 runs this at
     //    the execute() level before delegating to addRule (rules-mutations.ts).
     //    Scope uses the raw input scope so an unresolvable-project add with
     //    duplicates still returns the dup-refusal.

--- a/src/rust/daemon/mcp-server/src/tools/rules/parity_tests.rs
+++ b/src/rust/daemon/mcp-server/src/tools/rules/parity_tests.rs
@@ -375,6 +375,42 @@ async fn fix1_list_prefers_qdrant_over_mirror_when_both_available() {
 }
 
 #[tokio::test]
+async fn list_items_carry_owner_field() {
+    // alkmimm #134 salvage: every listed rule reports its owning tenant
+    // (project tenant_id, or "global") so an unresolved list cannot silently
+    // span tenants. A point with an explicit tenant_id reports that id; a
+    // tenant-less global point reports "global".
+    let mut d = PaDaemon::ok_no_embed();
+    let mut project_payload = HashMap::new();
+    project_payload.insert(
+        "content".to_string(),
+        Value::String("proj rule".to_string()),
+    );
+    project_payload.insert("scope".to_string(), Value::String("project".to_string()));
+    project_payload.insert("tenant_id".to_string(), Value::String("proj-7".to_string()));
+    let project_pt = QdrantRetrievedPoint {
+        id: "p-1".to_string(),
+        payload: project_payload,
+    };
+    let q = PaQdrant::scroll_ok(vec![project_pt, qdrant_retrieved("g-1", "global rule")]);
+    let r = PaReader::empty();
+    let input = RulesInput::from_args(&args(json!({ "action": "list" }))).unwrap();
+    let res = rules_tool(input, &mut d, &r, &q, None, None).await;
+    let j = get_json(&res);
+    let rules = j["rules"].as_array().unwrap();
+    assert_eq!(
+        rules[0]["owner"],
+        json!("proj-7"),
+        "project rule owner = tenant id"
+    );
+    assert_eq!(
+        rules[1]["owner"],
+        json!("global"),
+        "tenant-less rule owner = global"
+    );
+}
+
+#[tokio::test]
 async fn fix1_list_field_order_qdrant_success() {
     // success → action → rules → message
     let mut d = PaDaemon::ok_no_embed();

--- a/src/rust/daemon/mcp-server/src/tools/rules/parity_tests_part2.rs
+++ b/src/rust/daemon/mcp-server/src/tools/rules/parity_tests_part2.rs
@@ -7,7 +7,9 @@ use serde_json::json;
 
 use super::types::RulesInput;
 use super::*;
-use super::{args, get_json, get_text, qdrant_pt, top_keys, PaDaemon, PaQdrant, PaReader};
+use super::{
+    args, get_json, get_text, qdrant_pt, qdrant_retrieved, top_keys, PaDaemon, PaQdrant, PaReader,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // FIX 2 — add runs findSimilarRules dup-check before persisting
@@ -201,4 +203,78 @@ fn default_duplication_threshold_is_0_7() {
         (DEFAULT_DUPLICATION_THRESHOLD - 0.7).abs() < f64::EPSILON,
         "expected 0.7, got {DEFAULT_DUPLICATION_THRESHOLD}"
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Exact-content idempotency (alkmimm PR #134 salvage, 5e7497759 item 3)
+// A byte-identical rule in the same scope is a no-op, not a new row, and the
+// check is deterministic + fail-open.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn exact_content_duplicate_is_idempotent_noop() {
+    // An existing rule with byte-identical content → success no-op, no write,
+    // and the fuzzy embed/search gate never runs (it short-circuits earlier).
+    let mut d = PaDaemon::ok_with_embed(vec![0.1_f32; 384]);
+    let existing = qdrant_retrieved("rule-existing", "remember to use uv");
+    let q = PaQdrant::scroll_ok(vec![existing]);
+    let r = PaReader::empty();
+    let input = RulesInput::from_args(&args(json!({
+        "action": "add", "label": "use-uv", "content": "remember to use uv", "scope": "global"
+    })))
+    .unwrap();
+    let res = rules_tool(input, &mut d, &r, &q, None, None).await;
+    let j = get_json(&res);
+    assert_eq!(j["success"], json!(true));
+    assert!(
+        j["message"]
+            .as_str()
+            .unwrap()
+            .contains("Identical rule already exists"),
+        "got: {}",
+        j["message"]
+    );
+    assert_eq!(d.ingest_count(), 0, "no ingest on an idempotent re-add");
+    assert_eq!(
+        d.embed_count(),
+        0,
+        "exact match short-circuits before the fuzzy gate"
+    );
+    assert_eq!(q.search_count(), 0, "no fuzzy search on an exact match");
+}
+
+#[tokio::test]
+async fn exact_check_fails_open_on_scroll_error() {
+    // A scroll failure must NOT block the add (deterministic + fail-open).
+    let mut d = PaDaemon::ok_no_embed(); // empty embed → fuzzy gate skipped
+    let q = PaQdrant::scroll_err("qdrant down");
+    let r = PaReader::empty();
+    let input = RulesInput::from_args(&args(json!({
+        "action": "add", "label": "l", "content": "c", "scope": "global"
+    })))
+    .unwrap();
+    let res = rules_tool(input, &mut d, &r, &q, None, None).await;
+    let j = get_json(&res);
+    assert_eq!(j["success"], json!(true));
+    assert_eq!(j["message"], json!("Rule added successfully"));
+    assert_eq!(d.ingest_count(), 1, "scroll error must not block the add");
+}
+
+#[tokio::test]
+async fn near_but_not_identical_content_is_not_a_noop() {
+    // Only BYTE-identical content is a no-op; different content proceeds to add
+    // (where the fuzzy gate, not this exact check, governs similarity).
+    let mut d = PaDaemon::ok_no_embed(); // empty embed → fuzzy gate skipped
+    let existing = qdrant_retrieved("rule-1", "remember to use uv");
+    let q = PaQdrant::scroll_ok(vec![existing]);
+    let r = PaReader::empty();
+    let input = RulesInput::from_args(&args(json!({
+        "action": "add", "label": "l", "content": "remember to use poetry", "scope": "global"
+    })))
+    .unwrap();
+    let res = rules_tool(input, &mut d, &r, &q, None, None).await;
+    let j = get_json(&res);
+    assert_eq!(j["success"], json!(true));
+    assert_eq!(j["message"], json!("Rule added successfully"));
+    assert_eq!(d.ingest_count(), 1);
 }

--- a/src/rust/daemon/mcp-server/src/tools/rules/types.rs
+++ b/src/rust/daemon/mcp-server/src/tools/rules/types.rs
@@ -197,6 +197,14 @@ pub struct RuleItem {
     /// (rules.ts:153)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub similarity: Option<f64>,
+    /// Owning tenant of the rule — the project `tenant_id`, or `"global"`.
+    ///
+    /// Present only on `list` results (salvaged from alkmimm PR #134): an
+    /// unresolved project-scope list can span tenants, so each row says who owns
+    /// it instead of leaving that implicit. Emitted last to preserve the
+    /// TS-mirrored field order of the other keys; absent on `similar_rules`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
 }
 
 /// Rules tool response — mirrors TS `RuleResponse` (rules-types.ts:38-47).

--- a/src/rust/daemon/mcp-server/src/tools/rules_tests_part2.rs
+++ b/src/rust/daemon/mcp-server/src/tools/rules_tests_part2.rs
@@ -369,6 +369,7 @@ fn rule_item_field_order_in_list() {
         created_at: Some("2024-01-01T00:00:00Z".to_string()),
         updated_at: Some("2024-01-02T00:00:00Z".to_string()),
         similarity: None,
+        owner: None,
     };
     let text = serde_json::to_string_pretty(&item).unwrap();
     assert_eq!(
@@ -392,6 +393,7 @@ fn rule_item_field_order_with_all_optional_fields() {
         created_at: Some("2024-01-01T00:00:00Z".to_string()),
         updated_at: Some("2024-01-02T00:00:00Z".to_string()),
         similarity: None,
+        owner: None,
     };
     let text = serde_json::to_string_pretty(&item).unwrap();
     let keys = top_level_keys(&text);
@@ -440,6 +442,7 @@ fn rule_item_similarity_field_is_last() {
         created_at: None,
         updated_at: None,
         similarity: Some(0.857),
+        owner: None,
     };
     let text = serde_json::to_string_pretty(&item).unwrap();
     let keys = top_level_keys(&text);

--- a/src/rust/daemon/mcp-server/src/tools/search/mod.rs
+++ b/src/rust/daemon/mcp-server/src/tools/search/mod.rs
@@ -252,7 +252,10 @@ fn detect_project_id_from_cwd(
         .client_cwd
         .clone()
         .or_else(|| std::env::current_dir().ok())?;
-    resolve_cwd_project_id_locked(&cwd, state)
+    // Fold a Windows-host WSL UNC cwd to the POSIX path the daemon registered
+    // before the longest-prefix lookup; a no-op for native paths (#134 salvage).
+    let folded = wqm_common::paths::canonicalize_host_path(&cwd.to_string_lossy());
+    resolve_cwd_project_id_locked(std::path::Path::new(&folded), state)
 }
 
 /// Resolve a tenant id for `cwd` by longest-prefix `watch_folders` match.

--- a/src/rust/daemon/mcp-server/tests/conformance.rs
+++ b/src/rust/daemon/mcp-server/tests/conformance.rs
@@ -398,7 +398,7 @@ async fn retrieve_unresolved_scope_projects() {
     // collection=projects, no project_id → unresolved tenant response
     let mut args = serde_json::Map::new();
     args.insert("collection".to_string(), json!("projects"));
-    let input = RetrieveInput::from_args(&args);
+    let input = RetrieveInput::from_args(&args).expect("known args");
     let qdrant = RetrieveNotFound;
     let result = retrieve_tool(input, &qdrant, None).await;
     let actual: Value = serde_json::from_str(content_text(&result)).expect("valid json");
@@ -414,7 +414,7 @@ async fn retrieve_unresolved_scope_scratchpad() {
     let golden = load_golden("retrieve/unresolved_scope_scratchpad");
     let mut args = serde_json::Map::new();
     args.insert("collection".to_string(), json!("scratchpad"));
-    let input = RetrieveInput::from_args(&args);
+    let input = RetrieveInput::from_args(&args).expect("known args");
     let qdrant = RetrieveNotFound;
     let result = retrieve_tool(input, &qdrant, None).await;
     let actual: Value = serde_json::from_str(content_text(&result)).expect("valid json");


### PR DESCRIPTION
## Why this PR exists

Contributor @alkmimm opened two large PRs — #134 and #132 — that branch from a **568-commit-stale base** (2026-05-20) where the project still had a TypeScript MCP server at `src/typescript/mcp-server/`. `main` has since deleted that entire server and replaced it with the all-Rust `mcp-server`. **Neither PR can be merged or cherry-picked** — they target deleted code. Per the salvage plan, the *ideas* were analysed and conceptually ported to the current Rust code; alkmimm is credited as co-author on every ported commit.

Neither PR supersedes the other; together they carried ~6 portable ideas plus several that are moot under the all-Rust architecture. Full analysis lived in a read-only audit pass.

## What's ported here (5 read-path / validation / output-shaping changes — no writes, no ADR impact)

| Commit | Change |
|--------|--------|
| `retrieve rejects unknown args` | `retrieve({query: ...})` (the canonical mistake) now fails fast with a hint to use `search`, instead of silently dropping the arg and degrading into an unrelated scope error. |
| `strip ranking-aid keys` | Daemon-injected `keywords`/`concept_tags`/`structural_tags`/`keyword_baskets` (~1.5–2k tokens/hit) are stripped from default search + retrieve output. New `wqm_common::RANKING_AID_KEYS` is the single source of truth, with a producer-side guard test. |
| `rules idempotent add` | A byte-identical rule re-add in the same scope is now a success no-op (read-side pre-check, **no write enqueued** — respects enqueue-only), not a fuzzy-similarity refusal or a duplicate row. |
| `rules list owner` | Every listed rule reports its owning tenant (`project tenant_id` or `global`) so an unresolved list can't silently span tenants. |
| `WSL UNC cwd fold` | `wqm_common::paths::canonicalize_host_path` folds a Windows-host `\\wsl.localhost\<distro>\…` cwd to the POSIX path the in-WSL daemon registered; no-op for native paths. |

Each ported commit carries `Co-authored-by: alkmimm`.

## Discarded (with reasons)
- **Tag-expansion lexicon alignment** — moot: the Rust daemon has ONE service-local BM25 corpus, not per-collection lexicons, so the cross-vocabulary bug can't occur.
- **Registry indexed/registered tag** — TS-era JSON-vs-daemon reconciliation; Rust reads registration from SQLite (single source of truth).
- **Definition-site symbol boost** — alkmimm's own benchmark refuted it (top-1 34.1 → 25.0); default OFF.

## Deferred
- **Search-quality eval harness** (per-category verdict + real-query mining) → filed as #135. It's net-new dev tooling (L) with a schema migration that must sequence after the in-flight #133 queue-health migrations (v45/v46), so it doesn't belong in this read-path salvage PR.

## Testing
New unit tests for every ported behaviour; full suites green for `wqm-common`, `wqm-client`, `mcp-server` (746 + 350 + 454 …), plus the core producer-sync guard. `cargo clippy` clean across all touched packages.

## Follow-up
Once this merges, close #134 and #132 (unmerged) with a thank-you to @alkmimm referencing this PR and #135.

Refs #134, #132, #135.